### PR TITLE
base64 encode and decode content when disabling USE_ENCRYPTION

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,16 +7,21 @@ RUN apt-get update && \
     # For backend
     apt-get install -y python python-pip python-dev build-essential libffi-dev
 
-ADD . /srv/confidant
+ADD ./requirements.txt /srv/confidant/requirements.txt
+ADD ./package.json /srv/confidant/package.json
+ADD ./bower.json /srv/confidant/bower.json
 
 WORKDIR /srv/confidant
 
+RUN pip install -r requirements.txt
+
 RUN gem install compass && \
     npm install grunt-cli && \
-    npm install && \
-    node_modules/grunt-cli/bin/grunt build
+    npm install
 
-RUN pip install -r requirements.txt
+ADD . /srv/confidant
+
+RUN node_modules/grunt-cli/bin/grunt build
 
 EXPOSE 80
 

--- a/confidant/ciphermanager.py
+++ b/confidant/ciphermanager.py
@@ -1,3 +1,6 @@
+import base64
+import re
+
 from cryptography.fernet import Fernet
 
 from confidant import app
@@ -22,7 +25,7 @@ class CipherManager:
             log.warning('Not using encryption in CipherManager.encrypt'
                         ' If you are not running in a development or test'
                         ' environment, this should not be happening!')
-            return raw
+            return 'UNENCRYPTED_{0}'.format(base64.b64encode(raw))
         if self.version == 2:
             f = Fernet(self.key)
             return f.encrypt(raw.encode('utf-8'))
@@ -35,7 +38,7 @@ class CipherManager:
             log.warning('Not using encryption in CipherManager.decrypt'
                         ' If you are not running in a development or test'
                         ' environment, this should not be happening!')
-            return enc
+            return base64.b64decode(re.sub(r'^UNENCRYPTED_', '', enc))
         if self.version == 2:
             f = Fernet(self.key)
             return f.decrypt(enc.encode('utf-8'))

--- a/confidant/ciphermanager.py
+++ b/confidant/ciphermanager.py
@@ -25,7 +25,7 @@ class CipherManager:
             log.warning('Not using encryption in CipherManager.encrypt'
                         ' If you are not running in a development or test'
                         ' environment, this should not be happening!')
-            return 'UNENCRYPTED_{0}'.format(base64.b64encode(raw))
+            return 'DANGER_NOT_ENCRYPTED_{0}'.format(base64.b64encode(raw))
         if self.version == 2:
             f = Fernet(self.key)
             return f.encrypt(raw.encode('utf-8'))
@@ -38,7 +38,7 @@ class CipherManager:
             log.warning('Not using encryption in CipherManager.decrypt'
                         ' If you are not running in a development or test'
                         ' environment, this should not be happening!')
-            return base64.b64decode(re.sub(r'^UNENCRYPTED_', '', enc))
+            return base64.b64decode(re.sub(r'^DANGER_NOT_ENCRYPTED_', '', enc))
         if self.version == 2:
             f = Fernet(self.key)
             return f.decrypt(enc.encode('utf-8'))


### PR DESCRIPTION
If we don't use base64 when USE_ENCRYPTION is set to False, we get control character issues when json.loads is used. We had chosen to not base64 encode the data to make it very obvious in the database that encryption wasn't used, so in this change we're doing a base64, but we're prepending it with UNENCRYPTED_, so that if you look directly at the contents it's clear it's insecure.