### PR TITLE
Use logging directly and reorder imports for pep8

### DIFF
--- a/confidant/__init__.py
+++ b/confidant/__init__.py
@@ -1,10 +1,12 @@
-import boto3
 import logging
-import redis
 
+import boto3
+import redis
+import statsd
 from flask import Flask
 from flask.ext.session import Session
 from flask_sslify import SSLify
+
 from confidant import lru
 from confidant import settings
 
@@ -12,7 +14,6 @@ if not settings.get('DEBUG'):
     boto3.set_stream_logger(level=logging.CRITICAL)
     logging.getLogger('botocore').setLevel(logging.CRITICAL)
     logging.getLogger('pynamodb').setLevel(logging.WARNING)
-log = logging.getLogger(__name__)
 
 static_folder = settings.get('STATIC_FOLDER')
 
@@ -33,7 +34,6 @@ if app.config.get('REDIS_URL'):
 
 app.secret_key = app.config['SESSION_SECRET']
 
-import statsd
 stats = statsd.StatsClient(
     app.config['STATSD_HOST'],
     app.config['STATSD_PORT'],

--- a/confidant/ciphermanager.py
+++ b/confidant/ciphermanager.py
@@ -1,10 +1,10 @@
 import base64
 import re
+import logging
 
 from cryptography.fernet import Fernet
 
 from confidant import app
-from confidant import log
 
 
 class CipherManager:
@@ -22,9 +22,9 @@ class CipherManager:
     def encrypt(self, raw):
         # Disabled encryption is dangerous, so we don't use falsiness here.
         if app.config['USE_ENCRYPTION'] is False:
-            log.warning('Not using encryption in CipherManager.encrypt'
-                        ' If you are not running in a development or test'
-                        ' environment, this should not be happening!')
+            logging.warning('Not using encryption in CipherManager.encrypt'
+                            ' If you are not running in a development or test'
+                            ' environment, this should not be happening!')
             return 'DANGER_NOT_ENCRYPTED_{0}'.format(base64.b64encode(raw))
         if self.version == 2:
             f = Fernet(self.key)
@@ -35,9 +35,9 @@ class CipherManager:
     def decrypt(self, enc):
         # Disabled encryption is dangerous, so we don't use falsiness here.
         if app.config['USE_ENCRYPTION'] is False:
-            log.warning('Not using encryption in CipherManager.decrypt'
-                        ' If you are not running in a development or test'
-                        ' environment, this should not be happening!')
+            logging.warning('Not using encryption in CipherManager.decrypt'
+                            ' If you are not running in a development or test'
+                            ' environment, this should not be happening!')
             return base64.b64decode(re.sub(r'^DANGER_NOT_ENCRYPTED_', '', enc))
         if self.version == 2:
             f = Fernet(self.key)

--- a/confidant/graphite.py
+++ b/confidant/graphite.py
@@ -1,8 +1,8 @@
-from confidant import app
-from confidant import log
-
 import requests
 import json
+import logging
+
+from confidant import app
 
 
 def send_event(services, msg):
@@ -29,6 +29,6 @@ def send_event(services, msg):
         )
         if response.status_code != 200:
             msg = 'Post to graphite returned non-2000 status ({0}).'
-            log.warning(msg.format(response.status_code))
+            logging.warning(msg.format(response.status_code))
     except Exception as e:
-        log.warning('Failed to post graphite event. {0}'.format(e))
+        logging.warning('Failed to post graphite event. {0}'.format(e))

--- a/confidant/models/__init__.py
+++ b/confidant/models/__init__.py
@@ -1,9 +1,10 @@
 import time
 
+from pynamodb.exceptions import TableError
+
 from confidant import app
 from confidant.models.credential import Credential
 from confidant.models.service import Service
-from pynamodb.exceptions import TableError
 
 # Only used when using dynamodb local
 if app.config.get('DYNAMODB_URL'):

--- a/confidant/models/credential.py
+++ b/confidant/models/credential.py
@@ -1,5 +1,5 @@
-from confidant import app
 from datetime import datetime
+
 from pynamodb.models import Model
 from pynamodb.attributes import (
     UnicodeAttribute,
@@ -9,6 +9,8 @@ from pynamodb.attributes import (
     BinaryAttribute
 )
 from pynamodb.indexes import GlobalSecondaryIndex, AllProjection
+
+from confidant import app
 
 
 class DataTypeDateIndex(GlobalSecondaryIndex):

--- a/confidant/models/service.py
+++ b/confidant/models/service.py
@@ -1,5 +1,5 @@
-from confidant import app
 from datetime import datetime
+
 from pynamodb.models import Model
 from pynamodb.attributes import (
     UnicodeAttribute,
@@ -9,6 +9,8 @@ from pynamodb.attributes import (
     BooleanAttribute
 )
 from pynamodb.indexes import GlobalSecondaryIndex, AllProjection
+
+from confidant import app
 
 
 class DataTypeDateIndex(GlobalSecondaryIndex):

--- a/confidant/routes/static_files.py
+++ b/confidant/routes/static_files.py
@@ -1,10 +1,11 @@
 import os
+import logging
+
+from flask import send_from_directory
+from werkzeug.exceptions import NotFound
 
 from confidant import app
 from confidant import authnz
-from confidant import log
-from flask import send_from_directory
-from werkzeug.exceptions import NotFound
 
 
 @app.route('/')
@@ -70,7 +71,9 @@ def custom_modules(path):
             path
         )
     except NotFound:
-        log.warning('Client requested missing custom module {0}.'.format(path))
+        logging.warning(
+            'Client requested missing custom module {0}.'.format(path)
+        )
         return '', 200
 
 

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -1,17 +1,16 @@
 import sys
 import logging
-
 from flask.ext.script import Command
+from botocore.exceptions import ClientError
+
 from confidant import app
 from confidant import iam
 from confidant import kms
-from confidant import log
 from confidant import keymanager
 from confidant.models.service import Service
-from botocore.exceptions import ClientError
 
-log.addHandler(logging.StreamHandler(sys.stdout))
-log.setLevel(logging.INFO)
+logging.addHandler(logging.StreamHandler(sys.stdout))
+logging.setLevel(logging.INFO)
 
 
 class ManageGrants(Command):
@@ -21,16 +20,16 @@ class ManageGrants(Command):
         try:
             roles = [x for x in iam.roles.all()]
         except ClientError:
-            log.error('Failed to fetch IAM roles.')
+            logging.error('Failed to fetch IAM roles.')
             return
         services = []
         for service in Service.data_type_date_index.query('service'):
             services.append(service.id)
         for role in roles:
             if role.name in services:
-                log.info('Managing grants for {0}.'.format(role.name))
+                logging.info('Managing grants for {0}.'.format(role.name))
                 keymanager._ensure_grants(role, grants)
-        log.info('Finished managing grants.')
+        logging.info('Finished managing grants.')
 
 
 class RevokeGrants(Command):
@@ -42,4 +41,4 @@ class RevokeGrants(Command):
                 KeyId=keymanager.get_key_id(app.config['AUTH_KEY']),
                 GrantId=grant['GrantId']
             )
-        log.info('Finished revoking grants.')
+        logging.info('Finished revoking grants.')


### PR DESCRIPTION
This change switching from using a logging object to using logging directly. This fixes the logging issues in docker. This change also reorders the imports to match pep8 style.