### PR TITLE
Fix index title by correctly referencing index.headline

### DIFF
--- a/docs/helpers/guide_helpers.rb
+++ b/docs/helpers/guide_helpers.rb
@@ -6,7 +6,7 @@ module GuideHelpers
     if current_page.data.title
       title << current_page.data.title
     else
-      title << t("index.sub_title")
+      title << t("index.headline")
     end
     title
   end


### PR DESCRIPTION
The documentation homepage title is currently "Confidant: translation missing: en.index.sub_title" because it is referencing a missing key `index.sub_title`. I changed it to use `index.headline`.

#### Reviewers
@ryan-lane 