### PR TITLE
Define table region explicitly

### DIFF
--- a/confidant/models/credential.py
+++ b/confidant/models/credential.py
@@ -36,6 +36,7 @@ class Credential(Model):
         table_name = app.config.get('DYNAMODB_TABLE')
         if app.config.get('DYNAMODB_URL'):
             host = app.config.get('DYNAMODB_URL')
+        region = app.config.get('AWS_DEFAULT_REGION')
 
     id = UnicodeAttribute(hash_key=True)
     revision = NumberAttribute()

--- a/confidant/models/service.py
+++ b/confidant/models/service.py
@@ -36,6 +36,7 @@ class Service(Model):
         table_name = app.config.get('DYNAMODB_TABLE')
         if app.config.get('DYNAMODB_URL'):
             host = app.config.get('DYNAMODB_URL')
+        region = app.config.get('AWS_DEFAULT_REGION')
 
     id = UnicodeAttribute(hash_key=True)
     data_type = UnicodeAttribute()

--- a/confidant/settings.py
+++ b/confidant/settings.py
@@ -178,11 +178,8 @@ USE_ENCRYPTION = bool_env('USE_ENCRYPTION', True)
 
 # boto3 configuration
 
-# Note that it's important to set this environment variable, even though it
-# isn't exposed in app.config. Must be set to the region the server is running
-# in.
-#
-# AWS_DEFAULT_REGION='us-east-1'
+# Must be set to the region the server is running.
+AWS_DEFAULT_REGION = str_env('AWS_DEFAULT_REGION', 'us-east-1')
 
 # gevent configuration
 


### PR DESCRIPTION
Seems PynamoDB doesn't use AWS_DEFAULT_REGION, but instead has its own method of accessing tables by region, which is specific to the table creation. Set the region explicitly via AWS_DEFAULT_REGION.