### PR TITLE
Fix some bugs with NullUserAuthenticator and reworked login URLs

### DIFF
--- a/confidant/authnz/__init__.py
+++ b/confidant/authnz/__init__.py
@@ -60,7 +60,7 @@ def require_csrf_token(f):
     def decorated(*args, **kwargs):
         # If we're not using auth, there's no point in checking csrf tokens.
         if not app.config.get('USE_AUTH'):
-            return True
+            return f(*args, **kwargs)
         # KMS is username/password or header auth, so we don't need to check
         # for csrf tokens.
         if g.auth_type == 'kms':

--- a/confidant/authnz/userauth.py
+++ b/confidant/authnz/userauth.py
@@ -546,7 +546,10 @@ class SamlAuthenticator(AbstractUserAuthenticator):
         redirect_url = request.form.get('RelayState', default_redirect)
 
         # avoid redirect loop
-        if redirect_url.endswith('/v1/saml/consume'):
+        # This is enough of a pain that it's not clear that we should even
+        # support RelayState, but it seems good enough for now.
+        if (redirect_url.endswith('/saml/consume') or
+            redirect_url.endswith('/login')):
             redirect_url = default_redirect
 
         logging.debug("Redirecting to {0}".format(redirect_url))

--- a/confidant/authnz/userauth.py
+++ b/confidant/authnz/userauth.py
@@ -257,6 +257,10 @@ class NullUserAuthenticator(object):
         """Null users are always authenticated"""
         return True
 
+    def is_expired(self):
+        """Null users are never expired"""
+        return False
+
     def check_authorization(self):
         """Null users are always authorized"""
         return True


### PR DESCRIPTION
There are a few bugs from changes in the 1.1 branch fixed here:
- Define is_expired() method for NullUserAuthenticator objects, which don't inherit from AbstractUserAuthenticator.
- Fix require_csrf_token() decorator so it calls the wrapped function when USE_AUTH is false.
- Fix infinite SAML login loop that comes from dumb code in /v1/saml/consume that has a list of URLs that are known to be infinite loops.

https://github.com/lyft/confidant/commit/ab8bc60cdbc819e4c43b7a9b7f1a18ee0d43b321