### PR TITLE
Bumping cryptography=1.0.1 to 1.2 to mitigiate https://github.com/lyf…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ pynamodb==1.4.3
 # License: BSD
 # Upstream url: https://github.com/pyca/cryptography
 # Use: For encryption
-cryptography==1.2
+cryptography==1.2.3
 
 # License: BSD
 # Upstream url: https://github.com/fengsp/flask-session

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ pynamodb==1.4.3
 # License: BSD
 # Upstream url: https://github.com/pyca/cryptography
 # Use: For encryption
-cryptography==1.0.1
+cryptography==1.2
 
 # License: BSD
 # Upstream url: https://github.com/fengsp/flask-session


### PR DESCRIPTION
…t/confidant/issues/81

1.2 was the lowest version increment that resolved the issue 1.0.2 failed compilation in the same way as 1.0.1