### PR TITLE
Add a user authenticator that uses request headers

### DIFF
--- a/confidant/authnz/__init__.py
+++ b/confidant/authnz/__init__.py
@@ -1,7 +1,7 @@
 import fnmatch
 import logging
 
-from flask import abort, request, g
+from flask import abort, request, g, make_response
 from flask import url_for
 from functools import wraps
 
@@ -225,7 +225,7 @@ def require_auth(f):
                     g.user_type = user_type
                     g.auth_type = user_mod.auth_type
                     # ensure that the csrf cookie value is set
-                    resp = f(*args, **kwargs)
+                    resp = make_response(f(*args, **kwargs))
                     user_mod.set_csrf_token(resp)
                     return resp
 

--- a/confidant/authnz/__init__.py
+++ b/confidant/authnz/__init__.py
@@ -224,7 +224,10 @@ def require_auth(f):
                     # auth-N and auth-Z are good, call the decorated function
                     g.user_type = user_type
                     g.auth_type = user_mod.auth_type
-                    return f(*args, **kwargs)
+                    # ensure that the csrf cookie value is set
+                    resp = f(*args, **kwargs)
+                    user_mod.set_csrf_token(resp)
+                    return resp
 
             # Not authenticated
             return abort(401)

--- a/confidant/authnz/userauth.py
+++ b/confidant/authnz/userauth.py
@@ -344,7 +344,8 @@ class HeaderAuthenticator(AbstractUserAuthenticator):
     def log_in(self):
         self.assert_headers()
 
-        # Does nothing, since simply being able to reach this endpoint is 'logging in'.
+        # Does nothing, since simply being able to reach this endpoint is
+        # 'logging in'.
         resp = self.redirect_to_index()
         self.set_csrf_token(resp)
         return resp

--- a/confidant/authnz/userauth.py
+++ b/confidant/authnz/userauth.py
@@ -82,9 +82,10 @@ class AbstractUserAuthenticator(object):
         return session.get('XSRF-TOKEN')
 
     def set_csrf_token(self, resp):
-        session['XSRF-TOKEN'] = '{0:x}'.format(
-            random.SystemRandom().getrandbits(160)
-        )
+        if 'XSRF-TOKEN' not in session:
+            session['XSRF-TOKEN'] = '{0:x}'.format(
+                random.SystemRandom().getrandbits(160)
+            )
         resp.set_cookie('XSRF-TOKEN', session['XSRF-TOKEN'])
 
     def check_csrf_token(self):

--- a/confidant/authnz/userauth.py
+++ b/confidant/authnz/userauth.py
@@ -44,8 +44,9 @@ def init_user_auth_class(*args, **kwargs):
             raise ValueError(
                 'Unknown USER_AUTH_MODULE: {!r}'.format(module_name))
 
-    logging.info('Initializing {} user authenticator'.format(module.auth_type))
-    return module(*args, **kwargs)
+    auth = module(*args, **kwargs)
+    logging.info('Initializing {} user authenticator'.format(auth.auth_type))
+    return auth
 
 
 class AbstractUserAuthenticator(object):

--- a/confidant/settings.py
+++ b/confidant/settings.py
@@ -121,6 +121,7 @@ _secrets_bootstrap = _bootstrap(SECRETS_BOOTSTRAP)
 # Supported methods:
 # - 'google' # Google OAuth
 # - 'saml'   # SAML Identity Provider
+# - 'header' # Header-based authentication
 USER_AUTH_MODULE = str_env('USER_AUTH_MODULE', 'google')
 
 # An email suffix that can be used to restrict access to the web interface.
@@ -235,6 +236,20 @@ AUTHOMATIC_SALT = _secrets_bootstrap.get(
     'AUTHOMATIC_SALT',
     str_env('AUTHOMATIC_SALT')
 )
+
+# Header-based authentication
+
+# The name of the header that will contain the username.  Required if using
+# header authentication.
+HEADER_AUTH_USERNAME_HEADER = str_env('HEADER_AUTH_USERNAME_HEADER')
+# The name of the header that will contain the user's email.  Required if using
+# header authentication.
+HEADER_AUTH_EMAIL_HEADER = str_env('HEADER_AUTH_EMAIL_HEADER')
+# The name of the header that will contain the user's first name.  Optional.
+HEADER_AUTH_FIRST_NAME_HEADER = str_env('HEADER_AUTH_FIRST_NAME_HEADER')
+# The name of the header that will contain the user's last name.  Optional.
+HEADER_AUTH_LAST_NAME_HEADER = str_env('HEADER_AUTH_LAST_NAME_HEADER')
+
 
 # KMS service authentication
 


### PR DESCRIPTION
This commit adds a user authenticator that reads authentication from
request headers.  This is useful in the case that you have a load
balancer or other reverse proxy that performs authentication, and simply
being able to make a request to Confidant means that the user is
authenticated.