### PR TITLE
Make xsrf cookie name configurable

### DIFF
--- a/confidant/authnz/userauth.py
+++ b/confidant/authnz/userauth.py
@@ -80,20 +80,22 @@ class AbstractUserAuthenticator(object):
         return session['user']
 
     def get_csrf_token(self):
-        return session.get('XSRF-TOKEN')
+        return session.get(app.config['XSRF_COOKIE_NAME'])
 
     def set_csrf_token(self, resp):
-        if 'XSRF-TOKEN' not in session:
-            session['XSRF-TOKEN'] = '{0:x}'.format(
+        cookie_name = app.config['XSRF_COOKIE_NAME']
+        if cookie_name not in session:
+            session[cookie_name] = '{0:x}'.format(
                 random.SystemRandom().getrandbits(160)
             )
-        resp.set_cookie('XSRF-TOKEN', session['XSRF-TOKEN'])
+        resp.set_cookie(cookie_name, session[cookie_name])
 
     def check_csrf_token(self):
+        cookie_name = app.config['XSRF_COOKIE_NAME']
         token = request.headers.get('X-XSRF-TOKEN', '')
         if not token:
             return False
-        return safe_str_cmp(token, session.get('XSRF-TOKEN', ''))
+        return safe_str_cmp(token, session.get(cookie_name, ''))
 
     def set_expiration(self):
         if app.config['PERMANENT_SESSION_LIFETIME']:

--- a/confidant/public/modules/app.js
+++ b/confidant/public/modules/app.js
@@ -22,11 +22,14 @@
      * Main controller
      */
     .controller('ConfidantMainCtrl', [
-        '$scope', 'common.userinfo', 'common.clientconfig',
-        function ConfidantMainCtrl($scope, userinfo, clientconfig) {
+        '$scope', '$http', 'common.userinfo', 'common.clientconfig',
+        function ConfidantMainCtrl($scope, $http, userinfo, clientconfig) {
 
         $scope.user = userinfo.get();
-        $scope.clientconfig = clientconfig.get();
+        clientconfig.get().$promise.then(function(clientConfig) {
+            $scope.clientconfig = clientConfig;
+            $http.defaults.xsrfCookieName = clientConfig.generated.xsrf_cookie_name;
+        });
 
     }])
 

--- a/confidant/routes/v1.py
+++ b/confidant/routes/v1.py
@@ -59,7 +59,8 @@ def get_client_config():
         'defined': app.config['CLIENT_CONFIG'],
         'generated': {
             'kms_auth_manage_grants': app.config['KMS_AUTH_MANAGE_GRANTS'],
-            'aws_accounts': app.config['SCOPED_AUTH_KEYS'].values()
+            'aws_accounts': app.config['SCOPED_AUTH_KEYS'].values(),
+            'xsrf_cookie_name': app.config['XSRF_COOKIE_NAME']
         }
     })
     return response

--- a/confidant/settings.py
+++ b/confidant/settings.py
@@ -301,6 +301,9 @@ SSLIFY = bool_env('SSLIFY', True)
 # Cookie name for the session.
 SESSION_COOKIE_NAME = str_env('SESSION_COOKIE_NAME', 'confidant_session')
 
+# Cookie name for the XSRF token
+XSRF_COOKIE_NAME = str_env('XSRF_COOKIE_NAME', 'XSRF-TOKEN')
+
 # Session cache
 # Mutually exclusive with secure cookie session settings.
 

--- a/docs/source/basics/configuration.html.markdown
+++ b/docs/source/basics/configuration.html.markdown
@@ -95,6 +95,38 @@ TODO: As of Confidant version 1.1 it's possible to use SAML as an alternative
 to google authentication. We still need to document all of the options, though.
 Basic documentation for each SAML option is described in the settings.py file.
 
+### User authentication session settings
+
+By default (in confidant 1.1) confidant will use itsdangerous secure cookies
+for session management, with a session lifetime and maximum session lifetime. A
+user's session lifetime with automatically be extended any time a user performs
+any action in the interface, but the user's session lifetime can only be
+extended up to the maximum session lifetime, in which they'll be required to
+login again. The session lifetime and maximum session lifetime can be adjusted:
+
+```bash
+# Session lifetime in seconds. Default is 12 hours.
+export PERMANENT_SESSION_LIFETIME='43200'
+# Maximum session lifetime in seconds. Default is 24 hours.
+export MAX_PERMANENT_SESSION_LIFETIME='86400'
+```
+
+An alternative to using itsdangerous cookies is to store cookies in a redis
+backend:
+
+```bash
+export REDIS_URL='redis://localhost:6381'
+export PERMANENT_SESSION_LIFETIME='0'
+```
+
+It's possible to use custom cookie names for both the session cookie, and for
+the XSRF token cookie:
+
+```bash
+export SESSION_COOKIE_NAME='confidant_session'
+export XSRF_COOKIE_NAME='XSRF-TOKEN'
+```
+
 ## Advanced environment configuration
 
 ### statsd metrics
@@ -252,30 +284,6 @@ manually, or you'll need to manage your IAM policy for KMS.
 ```bash
 # Manage auth key grants for service to service authentication. Default True
 export KMS_AUTH_MANAGE_GRANTS='False'
-```
-
-### User authentication session settings
-
-By default (in confidant 1.1) confidant will use itsdangerous secure cookies
-for session management, with a session lifetime and maximum session lifetime. A
-user's session lifetime with automatically be extended any time a user performs
-any action in the interface, but the user's session lifetime can only be
-extended up to the maximum session lifetime, in which they'll be required to
-login again. The session lifetime and maximum session lifetime can be adjusted:
-
-```bash
-# Session lifetime in seconds. Default is 12 hours.
-export PERMANENT_SESSION_LIFETIME='43200'
-# Maximum session lifetime in seconds. Default is 24 hours.
-export MAX_PERMANENT_SESSION_LIFETIME='86400'
-```
-
-An alternative to using itsdangerous cookies is to store cookies in a redis
-backend:
-
-```bash
-export REDIS_URL='redis://localhost:6381'
-export PERMANENT_SESSION_LIFETIME='0'
 ```
 
 ### Confidant client configuration

--- a/tests/integration/confidant/authnz/authnz_test.py
+++ b/tests/integration/confidant/authnz/authnz_test.py
@@ -105,6 +105,7 @@ class AuthnzTest(unittest.TestCase):
         app.config['USER_AUTH_MODULE'] = 'header'
         app.config['HEADER_AUTH_USERNAME_HEADER'] = 'X-Confidant-User'
         app.config['HEADER_AUTH_EMAIL_HEADER'] = 'X-Confidant-Email'
+        app.config['XSRF_COOKIE_NAME'] = 'XSRF-TOKEN'
         user_mod = userauth.init_user_auth_class()
         with patch('confidant.authnz.user_mod', user_mod):
             ret = self.test_client.get(


### PR DESCRIPTION
This change makes it possible to modify the xsrf cookie name used by the web frontend. This can be used if the cookie name conflicts with another application in the same domain.