### PR TITLE
Toggle credential conflict check

### DIFF
--- a/confidant/routes/v1.py
+++ b/confidant/routes/v1.py
@@ -261,7 +261,7 @@ def map_service_credentials(id):
             data.get('credentials', []),
             data.get('blind_credentials', []),
         )
-        if conflicts:
+        if conflicts and not app.config['IGNORE_CONFLICTS']:
             ret = {
                 'error': 'Conflicting key pairs in mapped service.',
                 'conflicts': conflicts

--- a/confidant/routes/v1.py
+++ b/confidant/routes/v1.py
@@ -725,7 +725,7 @@ def update_credential(id):
             credential_pairs.keys(),
             services
         )
-        if conflicts:
+        if conflicts and not app.config['IGNORE_CONFLICTS']:
             ret = {
                 'error': 'Conflicting key pairs in mapped service.',
                 'conflicts': conflicts
@@ -1054,7 +1054,7 @@ def update_blind_credential(id):
             data['credential_keys'],
             services
         )
-        if conflicts:
+        if conflicts and not app.config['IGNORE_CONFLICTS']:
             ret = {
                 'error': 'Conflicting key pairs in mapped service.',
                 'conflicts': conflicts

--- a/confidant/routes/v1.py
+++ b/confidant/routes/v1.py
@@ -261,7 +261,7 @@ def map_service_credentials(id):
             data.get('credentials', []),
             data.get('blind_credentials', []),
         )
-        if conflicts and not app.config['IGNORE_CONFLICTS']:
+        if conflicts:
             ret = {
                 'error': 'Conflicting key pairs in mapped service.',
                 'conflicts': conflicts
@@ -488,6 +488,9 @@ def _get_blind_credentials(credential_ids):
 def _pair_key_conflicts_for_credentials(credential_ids, blind_credential_ids):
     conflicts = {}
     pair_keys = {}
+    # If we don't care about conflicts, return immediately
+    if app.config['IGNORE_CONFLICTS']:
+        return conflicts
     # For all credentials, get their credential pairs and track which
     # credentials have which keys
     credentials = _get_credentials(credential_ids)
@@ -568,6 +571,9 @@ def _get_service_map(services):
 
 def _pair_key_conflicts_for_services(_id, credential_keys, services):
     conflicts = {}
+    # If we don't care about conflicts, return immediately
+    if app.config['IGNORE_CONFLICTS']:
+        return conflicts
     service_map = _get_service_map(services)
     credential_ids = []
     blind_credential_ids = []
@@ -725,7 +731,7 @@ def update_credential(id):
             credential_pairs.keys(),
             services
         )
-        if conflicts and not app.config['IGNORE_CONFLICTS']:
+        if conflicts:
             ret = {
                 'error': 'Conflicting key pairs in mapped service.',
                 'conflicts': conflicts
@@ -1054,7 +1060,7 @@ def update_blind_credential(id):
             data['credential_keys'],
             services
         )
-        if conflicts and not app.config['IGNORE_CONFLICTS']:
+        if conflicts:
             ret = {
                 'error': 'Conflicting key pairs in mapped service.',
                 'conflicts': conflicts

--- a/confidant/settings.py
+++ b/confidant/settings.py
@@ -416,6 +416,12 @@ WEBHOOK_PASSWORD = _secrets_bootstrap.get(
     str_env('WEBHOOK_PASSWORD')
 )
 
+# Ignore conflicts of credential names in a service
+# This is used if you don't mind having more than one of the same key name
+# in different credentials associated with a service.
+IGNORE_CONFLICTS = bool_env('IGNORE_CONFLICTS', False)
+
+
 # Customization
 
 # Directory for customization of AngularJS frontend.


### PR DESCRIPTION
We have a use case where we need to be able to save credentials that have the same key names, and use them in the one service.

Since the credential itself acts like a kind of namespace, this looks safe to do, and as we're making the default match the current behaviour, only people who want this feature will get it.

To elaborate on the use case, we use the Service to map into a kubernetes namespace, and the Credentials inside this service with names like `kube-cluster-<clustername>` to contain the cluster details to connect to. Those key/value pairs will be the same (i.e `username`/`password`), so we need to turn off the conflict check.