### PR TITLE
Add manage script to create dynamo tables

### DIFF
--- a/confidant/models/__init__.py
+++ b/confidant/models/__init__.py
@@ -1,36 +1,7 @@
 import time
 
-from pynamodb.exceptions import TableError
-
 from confidant.app import app
-from confidant.models.credential import Credential
-from confidant.models.blind_credential import BlindCredential
-from confidant.models.service import Service
+from confidant.utils.dynamodb import create_dynamodb_tables
 
 if app.config['DYNAMODB_CREATE_TABLE']:
-    i = 0
-    # This loop is absurd, but there's race conditions with dynamodb local
-    while i < 5:
-        try:
-            if not Credential.exists():
-                Credential.create_table(
-                    read_capacity_units=10,
-                    write_capacity_units=10,
-                    wait=True
-                )
-            if not BlindCredential.exists():
-                BlindCredential.create_table(
-                    read_capacity_units=10,
-                    write_capacity_units=10,
-                    wait=True
-                )
-            if not Service.exists():
-                Service.create_table(
-                    read_capacity_units=10,
-                    write_capacity_units=10,
-                    wait=True
-                )
-            break
-        except TableError:
-            i = i + 1
-            time.sleep(2)
+    create_dynamodb_tables()

--- a/confidant/models/__init__.py
+++ b/confidant/models/__init__.py
@@ -1,5 +1,3 @@
-import time
-
 from confidant.app import app
 from confidant.utils.dynamodb import create_dynamodb_tables
 

--- a/confidant/scripts/bootstrap.py
+++ b/confidant/scripts/bootstrap.py
@@ -12,6 +12,7 @@ from flask.ext.script import Option
 from confidant import settings
 from confidant.app import app
 from confidant.lib import cryptolib
+from confidant.utils.dynamodb import create_dynamodb_tables
 
 app.logger.addHandler(logging.StreamHandler(sys.stdout))
 app.logger.setLevel(logging.INFO)
@@ -61,3 +62,11 @@ class DecryptSecretsBootstrap(Command):
         else:
             with open(os.path.join(_out), 'w') as f:
                 f.write(data)
+
+
+class CreateDynamoTables(Command):
+    """
+    Setup dynamo tables
+    """
+    def run(self):
+        create_dynamodb_tables()

--- a/confidant/scripts/bootstrap.py
+++ b/confidant/scripts/bootstrap.py
@@ -12,7 +12,6 @@ from flask.ext.script import Option
 from confidant import settings
 from confidant.app import app
 from confidant.lib import cryptolib
-from confidant.utils.dynamodb import create_dynamodb_tables
 
 app.logger.addHandler(logging.StreamHandler(sys.stdout))
 app.logger.setLevel(logging.INFO)
@@ -62,11 +61,3 @@ class DecryptSecretsBootstrap(Command):
         else:
             with open(os.path.join(_out), 'w') as f:
                 f.write(data)
-
-
-class CreateDynamoTables(Command):
-    """
-    Setup dynamo tables
-    """
-    def run(self):
-        create_dynamodb_tables()

--- a/confidant/scripts/manage.py
+++ b/confidant/scripts/manage.py
@@ -3,9 +3,9 @@ from flask.ext.script import Manager
 from confidant import app
 from confidant.scripts.utils import ManageGrants
 from confidant.scripts.utils import RevokeGrants
+from confidant.scripts.utils import CreateDynamoTables
 from confidant.scripts.bootstrap import GenerateSecretsBootstrap
 from confidant.scripts.bootstrap import DecryptSecretsBootstrap
-from confidant.scripts.bootstrap import CreateDynamoTables
 
 manager = Manager(app.app)
 

--- a/confidant/scripts/manage.py
+++ b/confidant/scripts/manage.py
@@ -5,6 +5,7 @@ from confidant.scripts.utils import ManageGrants
 from confidant.scripts.utils import RevokeGrants
 from confidant.scripts.bootstrap import GenerateSecretsBootstrap
 from confidant.scripts.bootstrap import DecryptSecretsBootstrap
+from confidant.scripts.bootstrap import CreateDynamoTables
 
 manager = Manager(app.app)
 
@@ -19,6 +20,9 @@ manager.add_command("generate_secrets_bootstrap", GenerateSecretsBootstrap)
 
 # Show the YAML formatted secrets_bootstrap in a decrypted form
 manager.add_command("decrypt_secrets_bootstrap", DecryptSecretsBootstrap)
+
+# Create dynamodb tables
+manager.add_command("create_dynamodb_tables", CreateDynamoTables)
 
 
 def main():

--- a/confidant/scripts/utils.py
+++ b/confidant/scripts/utils.py
@@ -7,6 +7,7 @@ import confidant.services
 from confidant import keymanager
 from confidant.app import app
 from confidant.models.service import Service
+from confidant.utils.dynamodb import create_dynamodb_tables
 
 iam_resource = confidant.services.get_boto_resource('iam')
 kms_client = confidant.services.get_boto_client('kms')
@@ -44,3 +45,11 @@ class RevokeGrants(Command):
                 GrantId=grant['GrantId']
             )
         app.logger.info('Finished revoking grants.')
+
+
+class CreateDynamoTables(Command):
+    """
+    Setup dynamo tables
+    """
+    def run(self):
+        create_dynamodb_tables()

--- a/confidant/utils/dynamodb.py
+++ b/confidant/utils/dynamodb.py
@@ -1,0 +1,34 @@
+from pynamodb.exceptions import TableError
+
+from confidant.models.credential import Credential
+from confidant.models.blind_credential import BlindCredential
+from confidant.models.service import Service
+
+
+def create_dynamodb_tables():
+    i = 0
+    # This loop is absurd, but there's race conditions with dynamodb local
+    while i < 5:
+        try:
+            if not Credential.exists():
+                Credential.create_table(
+                    read_capacity_units=10,
+                    write_capacity_units=10,
+                    wait=True
+                )
+            if not BlindCredential.exists():
+                BlindCredential.create_table(
+                    read_capacity_units=10,
+                    write_capacity_units=10,
+                    wait=True
+                )
+            if not Service.exists():
+                Service.create_table(
+                    read_capacity_units=10,
+                    write_capacity_units=10,
+                    wait=True
+                )
+            break
+        except TableError:
+            i = i + 1
+            time.sleep(2)

--- a/confidant/utils/dynamodb.py
+++ b/confidant/utils/dynamodb.py
@@ -1,3 +1,5 @@
+import time
+
 from pynamodb.exceptions import TableError
 
 from confidant.models.credential import Credential


### PR DESCRIPTION
In some cases (like running tests) we don't want to automatically create tables, but instead create them intentionally at a later time with a manage script.