### PR TITLE
Scale up dynamodb table

### DIFF
--- a/salt/orchestration/confidant.sls
+++ b/salt/orchestration/confidant.sls
@@ -14,8 +14,8 @@
 Ensure DynamoDB table exists:
   boto_dynamodb.present:
     - name: {{ grains.cluster_name }}
-    - read_capacity_units: 10
-    - write_capacity_units: 10
+    - read_capacity_units: 2500
+    - write_capacity_units: 30
     - hash_key: id
     - hash_key_data_type: S
     - global_indexes:


### PR DESCRIPTION
This change will scale up the table to at least 2x of the load we've seen in the past week (Friday evening specifically),

`INFO:ddb table: confidant-production-iad not scaled up for read, found violation at: 2017-09-30 01:37:00+00:00, consumed capacity: 919, provisioned capacity: 1500`