### PR TITLE
 Fix issue with angular trimming whitespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 # 1
 
+## 1.10.1
+
+* Fix an issue in the angularjs frontend where credential values were having whitespace trimmed.
+
 ## 1.10.0
 
 * Upgrade gevent and greenlet for CVE-2016-5180 and gevent/gevent#477

--- a/confidant/public/modules/resources/views/credential-details.html
+++ b/confidant/public/modules/resources/views/credential-details.html
@@ -54,7 +54,7 @@
           <div class="col-md-6 has-margin-bottom-lg">
             <div class="row">
               <div class="col-md-10">
-                <span class="dont-break-out" e-class="textarea-fullwidth dont-break-out" editable-textarea="credentialPair.value" e-rows="5" e-required>{{ showValue(credentialPair) }}</span>
+                <span class="dont-break-out" e-class="textarea-fullwidth dont-break-out" editable-textarea="credentialPair.value" e-ng-trim="false" e-rows="5" e-required>{{ showValue(credentialPair) }}</span>
               </div>
               <div class="col-md-2" ng-show="!editableForm.$visible">
                 <a ng-click="toggleCredentialMask(credentialPair)" ng-show="!credentialPair.shown && !editableForm.$visible"><span class="glyphicon glyphicon-eye-open"></span></a>

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ with open('requirements.in') as f:
 
 setup(
     name="confidant",
-    version="1.10.0",
+    version="1.10.1",
     packages=find_packages(exclude=["test*"]),
     include_package_data=True,
     zip_safe=False,


### PR DESCRIPTION
Seems by default for text areas that angularjs trims whitespace. This sets ng-trim to false for credential values. Fixes #156.