### PR TITLE
Always read users file, rather than caching in-memory forever

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 4.2.0
+
+* Don't in-memory cache the USERS\_FILE, but re-read it every time, so that
+  the confidant process doesn't need to restarted whenever this file changes.
+
 ## 4.1.0
 
 * Switch from python-saml to python3-saml.

--- a/confidant/authnz/userauth.py
+++ b/confidant/authnz/userauth.py
@@ -183,13 +183,12 @@ class AbstractUserAuthenticator(object):
         A whitelist of authorized email addresses or None.
         Loaded from config['USERS_FILE'] as YAML.
         """
-        if not hasattr(self, '_email_whitelist'):
-            self._email_whitelist = None
-            if app.config['USERS_FILE']:
-                with open(app.config['USERS_FILE'], 'r') as f:
-                    self._email_whitelist = yaml.safe_load(f.read())
+        _email_whitelist = None
+        if app.config['USERS_FILE']:
+            with open(app.config['USERS_FILE'], 'r') as f:
+                _email_whitelist = yaml.safe_load(f.read())
 
-        return self._email_whitelist
+        return _email_whitelist
 
     @property
     def allowed_email_suffix(self):

--- a/confidant/authnz/userauth.py
+++ b/confidant/authnz/userauth.py
@@ -183,6 +183,8 @@ class AbstractUserAuthenticator(object):
         A whitelist of authorized email addresses or None.
         Loaded from config['USERS_FILE'] as YAML.
         """
+        # TODO: cache the _email_whitelist in memory for some configurable
+        # amount of time.
         _email_whitelist = None
         if app.config['USERS_FILE']:
             with open(app.config['USERS_FILE'], 'r') as f:

--- a/confidant/authnz/userauth.py
+++ b/confidant/authnz/userauth.py
@@ -183,8 +183,8 @@ class AbstractUserAuthenticator(object):
         A whitelist of authorized email addresses or None.
         Loaded from config['USERS_FILE'] as YAML.
         """
-        # TODO: cache the _email_whitelist in memory for some configurable
-        # amount of time.
+        # TODO: cache the _email_whitelist in memory, and check the file mtime
+        # to determine if the cache needs to be refreshed.
         _email_whitelist = None
         if app.config['USERS_FILE']:
             with open(app.config['USERS_FILE'], 'r') as f:

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ with open('requirements.in') as f:
 
 setup(
     name="confidant",
-    version="4.1.0",
+    version="4.2.0",
     packages=find_packages(exclude=["test*"]),
     include_package_data=True,
     zip_safe=False,


### PR DESCRIPTION
Currently, once confidant loads and the users file is read once, it's cached for the lifetime of the process. It's possible the user data could be runtime data, so it's better to load it every time. This will make the UI slightly slower. I've added a TODO to cache this and to always check the mtime of the file to see if the cache needs to be refreshed.