### PR TITLE
Minor Dockerfile updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,12 @@
 FROM ubuntu:trusty
-MAINTAINER Ryan Lane <rlane@lyft.com>
+LABEL maintainer="rlane@lyft.com"
 
-RUN apt-get update && \
-    apt-get install -y curl && \
-    curl -sL https://deb.nodesource.com/setup_7.x | bash -
-RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        curl ca-certificates \
+    && /usr/bin/curl -sL --fail https://deb.nodesource.com/setup_8.x | bash -
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         # For frontend
         make ruby-dev nodejs git-core \
         # For backend
@@ -37,4 +38,4 @@ RUN node_modules/grunt-cli/bin/grunt build
 
 EXPOSE 80
 
-CMD ["gunicorn","confidant.wsgi:app","--workers=2","-k","gevent","--access-logfile=-","--error-logfile=-"]
+CMD ["gunicorn", "confidant.wsgi:app", "--workers=2", "-k", "gevent", "--access-logfile=-", "--error-logfile=-"]


### PR DESCRIPTION
* Update `MAINTAINER` to `LABEL maintainer=`
* Bump node version to 8 LTS
* install ca-certificates so curl call doesn't fail because of cert validation
* add `--fail` option to curl so it exits non-0 if something does fail
* add `DEBIAN_FRONTEND=noninteractive` and `--no-install-recommends` to other
  `apt-get` call

I also adjusted some of the formatting to be a little more consistent, and added spaces in the `CMD` array (I think this looks nicer, but could take it out).

I didn't add it here, but might also be interesting to add some of the labels from http://label-schema.org/