### PR TITLE
Added support for multiple webhooks declared in a JSON file

### DIFF
--- a/confidant/settings.py
+++ b/confidant/settings.py
@@ -379,6 +379,22 @@ WEBHOOK_PASSWORD = encrypted_settings.register(
     'WEBHOOK_PASSWORD',
     str_env('WEBHOOK_PASSWORD')
 )
+# Webhook Array File configuration
+# Example:
+# cat webhook_file.json
+# [
+#   {
+#     "WEBHOOK_URL": "https://webhook_dev.example.com"
+#   },
+#   {
+#     "WEBHOOK_URL": "https://webhook_test.example.com",
+#     "WEBHOOK_USERNAME": "myhookuser",
+#     "WEBHOOK_PASSWORD": "mylongandsupersecurehookpassword"
+#   }
+# ]
+# Extends the above standard webhook configuration to allow for more
+# integrations
+WEBHOOK_ARRAY_FILE = str_env('WEBHOOK_ARRAY_FILE')
 
 # Ignore conflicts of credential names in a service
 # This is used if you don't mind having more than one of the same key name

--- a/confidant/webhook.py
+++ b/confidant/webhook.py
@@ -49,6 +49,7 @@ def send_event(event_type, services, credential_ids):
     except EnvironmentError:
         logging.warning('Failed to open file: {0}'.format(webhook_file))
 
+
 def post_webhook(endpoint, event_type, services, credential_ids):
     try:
         logging.debug('Endpoint: ' + endpoint['WEBHOOK_URL'])
@@ -64,7 +65,7 @@ def post_webhook(endpoint, event_type, services, credential_ids):
         if 'WEBHOOK_USERNAME' in endpoint:
             logging.debug('Username: ' + endpoint['WEBHOOK_USERNAME'])
             username = endpoint['WEBHOOK_USERNAME']
-            password = endpoint['WEBHOOK_PASSWORD'] # Assumed if above
+            password = endpoint['WEBHOOK_PASSWORD']  # Assumed if above
             response = requests.post(
                 webhook_url,
                 auth=(username, password),

--- a/confidant/webhook.py
+++ b/confidant/webhook.py
@@ -31,5 +31,39 @@ def send_event(event_type, services, credential_ids):
             msg = 'Post to webhook returned non-200 status ({0}).'
             logging.warning(msg.format(response.status_code))
         logging.warning("webhook triggered: {}".format(event))
+
+        # New logic to support reading Webhook configuration from a file
+        webhook_file = app.config.get('WEBHOOK_ARRAY_FILE')
+        if not webhook_file:
+            logging.debug('Failed to find WEBHOOK_ARRAY_FILE in config')
+            return
+        with open(webhook_file) as json_file:
+            webhook_array = json.load(json_file)
+            for endpoint in webhook_array:
+                logging.debug('Endpoint: ' + endpoint['WEBHOOK_URL'])
+                if 'WEBHOOK_USERNAME' in endpoint:
+                    logging.debug('Username: ' + endpoint['WEBHOOK_USERNAME'])
+                    username = endpoint['WEBHOOK_USERNAME']
+                    password = endpoint['WEBHOOK_PASSWORD']
+                webhook_url = endpoint['WEBHOOK_URL']
+
+                headers = {'Content-type': 'application/json', 'Accept': 'text/plain'}
+
+                event = {
+                    'event_type': event_type,
+                    'services': services,
+                    'credentials': credential_ids
+                }
+                response = requests.post(
+                    webhook_url,
+                    auth=(username, password),
+                    headers=headers,
+                    data=json.dumps(event),
+                    timeout=3
+                )
+                if response.status_code != 200:
+                    msg = 'Post to webhook returned non-200 status ({0}).'
+                    logging.warning(msg.format(response.status_code))
+                logging.warning("webhook triggered: {}".format(event))
     except Exception as e:
         logging.warning('Failed to post webhook event. {0}'.format(e))

--- a/confidant/webhook.py
+++ b/confidant/webhook.py
@@ -31,39 +31,54 @@ def send_event(event_type, services, credential_ids):
             msg = 'Post to webhook returned non-200 status ({0}).'
             logging.warning(msg.format(response.status_code))
         logging.warning("webhook triggered: {}".format(event))
+    except Exception as e:
+        logging.warning('Failed to post webhook event. {0}'.format(e))
 
-        # New logic to support reading Webhook configuration from a file
-        webhook_file = app.config.get('WEBHOOK_ARRAY_FILE')
-        if not webhook_file:
-            logging.debug('Failed to find WEBHOOK_ARRAY_FILE in config')
-            return
+    # New logic to support reading Webhook configuration from a file
+    webhook_file = app.config.get('WEBHOOK_ARRAY_FILE')
+    if not webhook_file:
+        logging.debug('Failed to find WEBHOOK_ARRAY_FILE in config')
+        return
+    try:
         with open(webhook_file) as json_file:
             webhook_array = json.load(json_file)
             for endpoint in webhook_array:
-                logging.debug('Endpoint: ' + endpoint['WEBHOOK_URL'])
-                if 'WEBHOOK_USERNAME' in endpoint:
-                    logging.debug('Username: ' + endpoint['WEBHOOK_USERNAME'])
-                    username = endpoint['WEBHOOK_USERNAME']
-                    password = endpoint['WEBHOOK_PASSWORD']
-                webhook_url = endpoint['WEBHOOK_URL']
+                try:
+                    logging.debug('Endpoint: ' + endpoint['WEBHOOK_URL'])
+                    webhook_url = endpoint['WEBHOOK_URL']
+                    headers = {'Content-type': 'application/json', 'Accept': 'text/plain'}
 
-                headers = {'Content-type': 'application/json', 'Accept': 'text/plain'}
-
-                event = {
-                    'event_type': event_type,
-                    'services': services,
-                    'credentials': credential_ids
-                }
-                response = requests.post(
-                    webhook_url,
-                    auth=(username, password),
-                    headers=headers,
-                    data=json.dumps(event),
-                    timeout=3
-                )
-                if response.status_code != 200:
-                    msg = 'Post to webhook returned non-200 status ({0}).'
-                    logging.warning(msg.format(response.status_code))
-                logging.warning("webhook triggered: {}".format(event))
-    except Exception as e:
-        logging.warning('Failed to post webhook event. {0}'.format(e))
+                    event = {
+                        'event_type': event_type,
+                        'services': services,
+                        'credentials': credential_ids
+                    }
+                    response = []
+                    if 'WEBHOOK_USERNAME' in endpoint:
+                        logging.debug('Username: ' + endpoint['WEBHOOK_USERNAME'])
+                        username = endpoint['WEBHOOK_USERNAME']
+                        password = endpoint['WEBHOOK_PASSWORD'] # Assumed if above
+                        response = requests.post(
+                            webhook_url,
+                            auth=(username, password),
+                            headers=headers,
+                            data=json.dumps(event),
+                            timeout=3
+                        )
+                    else:
+                        response = requests.post(
+                            webhook_url,
+                            headers=headers,
+                            data=json.dumps(event),
+                            timeout=3
+                        )
+                    if response.status_code != 200:
+                        msg = 'Post to webhook returned non-200 status ({0}).'
+                        logging.warning(msg.format(response.status_code))
+                    logging.warning("webhook triggered: {}".format(event))
+                except Exception as e:
+                    logging.warning('Failed to post webhook event. {0}'.format(e))
+    except ValueError as e:
+        logging.warning('Failed to decode JSON file: {0}'.format(webhook_file))
+    except EnvironmentError:
+        logging.warning('Failed to open file: {0}'.format(webhook_file))

--- a/confidant/webhook.py
+++ b/confidant/webhook.py
@@ -43,42 +43,45 @@ def send_event(event_type, services, credential_ids):
         with open(webhook_file) as json_file:
             webhook_array = json.load(json_file)
             for endpoint in webhook_array:
-                try:
-                    logging.debug('Endpoint: ' + endpoint['WEBHOOK_URL'])
-                    webhook_url = endpoint['WEBHOOK_URL']
-                    headers = {'Content-type': 'application/json', 'Accept': 'text/plain'}
-
-                    event = {
-                        'event_type': event_type,
-                        'services': services,
-                        'credentials': credential_ids
-                    }
-                    response = []
-                    if 'WEBHOOK_USERNAME' in endpoint:
-                        logging.debug('Username: ' + endpoint['WEBHOOK_USERNAME'])
-                        username = endpoint['WEBHOOK_USERNAME']
-                        password = endpoint['WEBHOOK_PASSWORD'] # Assumed if above
-                        response = requests.post(
-                            webhook_url,
-                            auth=(username, password),
-                            headers=headers,
-                            data=json.dumps(event),
-                            timeout=3
-                        )
-                    else:
-                        response = requests.post(
-                            webhook_url,
-                            headers=headers,
-                            data=json.dumps(event),
-                            timeout=3
-                        )
-                    if response.status_code != 200:
-                        msg = 'Post to webhook returned non-200 status ({0}).'
-                        logging.warning(msg.format(response.status_code))
-                    logging.warning("webhook triggered: {}".format(event))
-                except Exception as e:
-                    logging.warning('Failed to post webhook event. {0}'.format(e))
+                post_webhook(endpoint, event_type, services, credential_ids)
     except ValueError as e:
         logging.warning('Failed to decode JSON file: {0}'.format(webhook_file))
     except EnvironmentError:
         logging.warning('Failed to open file: {0}'.format(webhook_file))
+
+def post_webhook(endpoint, event_type, services, credential_ids):
+    try:
+        logging.debug('Endpoint: ' + endpoint['WEBHOOK_URL'])
+        webhook_url = endpoint['WEBHOOK_URL']
+        headers = {'Content-type': 'application/json', 'Accept': 'text/plain'}
+
+        event = {
+            'event_type': event_type,
+            'services': services,
+            'credentials': credential_ids
+        }
+        response = []
+        if 'WEBHOOK_USERNAME' in endpoint:
+            logging.debug('Username: ' + endpoint['WEBHOOK_USERNAME'])
+            username = endpoint['WEBHOOK_USERNAME']
+            password = endpoint['WEBHOOK_PASSWORD'] # Assumed if above
+            response = requests.post(
+                webhook_url,
+                auth=(username, password),
+                headers=headers,
+                data=json.dumps(event),
+                timeout=3
+            )
+        else:
+            response = requests.post(
+                webhook_url,
+                headers=headers,
+                data=json.dumps(event),
+                timeout=3
+            )
+        if response.status_code != 200:
+            msg = 'Post to webhook returned non-200 status ({0}).'
+            logging.warning(msg.format(response.status_code))
+        logging.warning("webhook triggered: {}".format(event))
+    except Exception as e:
+        logging.warning('Failed to post webhook event. {0}'.format(e))


### PR DESCRIPTION
As mentioned in[this issue](https://github.com/lyft/confidant/issues/186) I want to be able to send multiple webhooks from Confidant when a secret (service or credential) is updated.

I went with a JSON configuration file which can be mounted onto the running container and the `WEBHOOK_ARRAY_FILE` environment variable storing the location of the file which can be retrieved.

The logic is purposefully kept separate from the existing Webhook functionality.

The only other thing possibly worth justifying was the try/except block - I wanted other Webhook list items not to fail if an earlier listed webhook endpoint returned a failed response (e.g. username+password authentication failure or a general 50x backend error).