### PR TITLE
Use revert endpoint for reverting service and add metadata only fetch

### DIFF
--- a/confidant/models/service.py
+++ b/confidant/models/service.py
@@ -45,3 +45,12 @@ class Service(Model):
     account = UnicodeAttribute(null=True)
     modified_date = UTCDateTimeAttribute(default=datetime.now)
     modified_by = UnicodeAttribute()
+
+    def equals(self, other_service):
+        if self.credentials != other_service.credentials:
+            return False
+        if self.blind_credentials != other_service.blind_credentials:
+            return False
+        if self.account != other_service.account:
+            return False
+        return True

--- a/confidant/public/modules/common/constants.js
+++ b/confidant/public/modules/common/constants.js
@@ -13,7 +13,6 @@
         USEREMAIL: 'v1/user/email',
         DATAKEY: 'v1/datakey',
         SERVICE: 'v1/services/:id',
-        SERVICE_METADATA: 'v1/services/:id/metadata',
         SERVICE_REVISION: 'v1/services/:id/:revision',
         SERVICES: 'v1/services',
         GRANTS: 'v1/grants/:id',

--- a/confidant/public/modules/common/constants.js
+++ b/confidant/public/modules/common/constants.js
@@ -13,6 +13,8 @@
         USEREMAIL: 'v1/user/email',
         DATAKEY: 'v1/datakey',
         SERVICE: 'v1/services/:id',
+        SERVICE_METADATA: 'v1/services/:id/metadata',
+        SERVICE_REVISION: 'v1/services/:id/:revision',
         SERVICES: 'v1/services',
         GRANTS: 'v1/grants/:id',
         ARCHIVE_SERVICES: 'v1/archive/services',

--- a/confidant/public/modules/history/controllers/BlindCredentialHistoryCtrl.js
+++ b/confidant/public/modules/history/controllers/BlindCredentialHistoryCtrl.js
@@ -69,6 +69,14 @@
                 }
             });
 
+            $scope.getCredentialByID = function(id) {
+                return $filter('filter')($scope.$parent.credentialList, {'id': id})[0];
+            };
+
+            $scope.getBlindCredentialByID = function(id) {
+                return $filter('filter')($scope.$parent.blindCredentialList, {'id': id})[0];
+            };
+
             $scope.revertToDiffRevision = function() {
                 var deferred = $q.defer();
                 if (angular.equals($scope.diffBlindCredential.name, $scope.currentBlindCredential.name) &&

--- a/confidant/public/modules/history/controllers/CredentialHistoryCtrl.js
+++ b/confidant/public/modules/history/controllers/CredentialHistoryCtrl.js
@@ -69,6 +69,14 @@
                 }
             });
 
+            $scope.getCredentialByID = function(id) {
+                return $filter('filter')($scope.$parent.credentialList, {'id': id})[0];
+            };
+
+            $scope.getBlindCredentialByID = function(id) {
+                return $filter('filter')($scope.$parent.blindCredentialList, {'id': id})[0];
+            };
+
             $scope.revertToDiffRevision = function() {
                 var deferred = $q.defer();
                 if (angular.equals($scope.diffCredential.name, $scope.currentCredential.name) &&

--- a/confidant/public/modules/history/controllers/ServiceHistoryCtrl.js
+++ b/confidant/public/modules/history/controllers/ServiceHistoryCtrl.js
@@ -45,6 +45,14 @@
                 }
             });
 
+            $scope.getCredentialByID = function(id) {
+                return $filter('filter')($scope.$parent.credentialList, {'id': id})[0];
+            };
+
+            $scope.getBlindCredentialByID = function(id) {
+                return $filter('filter')($scope.$parent.blindCredentialList, {'id': id})[0];
+            };
+
             $scope.getServiceByRevision = function(rev) {
                 return $filter('filter')($scope.revisions, {revision: rev})[0];
             };
@@ -72,17 +80,8 @@
             };
 
             $scope.revertToDiffRevision = function() {
-                var diffService = $scope.getServiceByRevision($scope.diffRevision),
-                    currentService = $scope.getServiceByRevision($scope.currentRevision),
-                    deferred = $q.defer();
-                if (angular.equals(diffService.credentials, currentService.credentials) &&
-                    angular.equals(diffService.blind_credentials, currentService.blind_credentials) &&
-                    angular.equals(diffService.enabled, currentService.enabled)) {
-                    $scope.saveError = 'Can not revert to revision ' + diffService.revision + '. No difference between it and current revision.';
-                    deferred.reject();
-                    return deferred.promise;
-                }
-                Service.update({'id': $scope.serviceId}, diffService).$promise.then(function(newService) {
+                var deferred = $q.defer();
+                Service.revert({'id': $scope.serviceId, revision: $scope.diffRevision}).$promise.then(function(newService) {
                     deferred.resolve();
                     ResourceArchiveService.updateResourceArchive();
                     $location.path('/history/service/' + newService.id + '-' + newService.revision);

--- a/confidant/public/modules/resources/services/confidantservices.js
+++ b/confidant/public/modules/resources/services/confidantservices.js
@@ -15,8 +15,8 @@
     }])
 
     .factory('services.service', ['$resource', 'CONFIDANT_URLS', function($resource, CONFIDANT_URLS) {
-        return $resource(CONFIDANT_URLS.SERVICE_METADATA, {id: '@id', revision: '@revision'}, {
-            update: {method: 'PUT', isArray: false, url: CONFIDANT_URLS.SERVICE},
+        return $resource(CONFIDANT_URLS.SERVICE, {id: '@id', revision: '@revision', metadata_only: true}, {
+            update: {method: 'PUT', isArray: false},
             revert: {method: 'PUT', isArray: false, url: CONFIDANT_URLS.SERVICE_REVISION}
         });
     }])

--- a/confidant/public/modules/resources/services/confidantservices.js
+++ b/confidant/public/modules/resources/services/confidantservices.js
@@ -15,8 +15,9 @@
     }])
 
     .factory('services.service', ['$resource', 'CONFIDANT_URLS', function($resource, CONFIDANT_URLS) {
-        return $resource(CONFIDANT_URLS.SERVICE, {id: '@id'}, {
-            update: {method: 'PUT', isArray: false}
+        return $resource(CONFIDANT_URLS.SERVICE_METADATA, {id: '@id', revision: '@revision'}, {
+            update: {method: 'PUT', isArray: false, url: CONFIDANT_URLS.SERVICE},
+            revert: {method: 'PUT', isArray: false, url: CONFIDANT_URLS.SERVICE_REVISION}
         });
     }])
 

--- a/confidant/routes/v1.py
+++ b/confidant/routes/v1.py
@@ -109,6 +109,13 @@ def get_service(id):
             logging.warning('Authz failed for service {0}.'.format(id))
             msg = 'Authenticated user is not authorized.'
             return jsonify({'error': msg}), 401
+    else:
+        logging.info(
+            'get_service called on id {} by {}'.format(
+                id,
+                authnz.get_logged_in_user()
+            )
+        )
     try:
         service = Service.get(id)
         if not authnz.service_in_account(service.account):
@@ -130,6 +137,39 @@ def get_service(id):
         return jsonify({'error': 'Decryption error.'}), 500
     blind_credentials = credentialmanager.get_blind_credentials(
         service.blind_credentials
+    )
+    return jsonify({
+        'id': service.id,
+        'account': service.account,
+        'credentials': credentials,
+        'blind_credentials': blind_credentials,
+        'enabled': service.enabled,
+        'revision': service.revision,
+        'modified_date': service.modified_date,
+        'modified_by': service.modified_by
+    })
+
+
+@app.route('/v1/services/<id>/metadata', methods=['GET'])
+@authnz.require_auth
+def get_service_metadata(id):
+    '''
+    Get service metadata
+    '''
+    try:
+        service = Service.get(id)
+    except DoesNotExist:
+        return jsonify({}), 404
+    if (service.data_type != 'service' and
+            service.data_type != 'archive-service'):
+        return jsonify({}), 404
+    credentials = credentialmanager.get_credentials(
+        service.credentials,
+        metadata_only=True,
+    )
+    blind_credentials = credentialmanager.get_blind_credentials(
+        service.blind_credentials,
+        metadata_only=True,
     )
     return jsonify({
         'id': service.id,
@@ -262,11 +302,13 @@ def map_service_credentials(id):
         if _service.data_type != 'service':
             msg = 'id provided is not a service.'
             return jsonify({'error': msg}), 400
-        revision = _service.revision + 1
-        _service_credential_ids = _service.credentials
+        revision = servicemanager.get_latest_service_revision(
+            id,
+            _service.revision
+        )
     except DoesNotExist:
         revision = 1
-        _service_credential_ids = []
+        _service = None
 
     if data.get('credentials') or data.get('blind_credentials'):
         conflicts = credentialmanager.pair_key_conflicts_for_credentials(
@@ -324,18 +366,117 @@ def map_service_credentials(id):
     except PutError as e:
         logging.error(e)
         return jsonify({'error': 'Failed to update active service.'}), 500
-    added = list(set(service.credentials) - set(_service_credential_ids))
-    removed = list(set(_service_credential_ids) - set(service.credentials))
-    msg = 'Added credentials: {0}; Removed credentials {1}; Revision {2}'
-    msg = msg.format(added, removed, service.revision)
-    graphite.send_event([id], msg)
+    servicemanager.send_service_mapping_graphite_event(service, _service)
     webhook.send_event('service_update', [service.id], service.credentials)
-    try:
-        credentials = credentialmanager.get_credentials(service.credentials)
-    except KeyError:
-        return jsonify({'error': 'Decryption error.'}), 500
+    credentials = credentialmanager.get_credentials(
+        service.credentials,
+        metadata_only=True,
+    )
     blind_credentials = credentialmanager.get_blind_credentials(
-        service.blind_credentials
+        service.blind_credentials,
+        metadata_only=True,
+    )
+    return jsonify({
+        'id': service.id,
+        'account': service.account,
+        'credentials': credentials,
+        'blind_credentials': blind_credentials,
+        'revision': service.revision,
+        'enabled': service.enabled,
+        'modified_date': service.modified_date,
+        'modified_by': service.modified_by
+    })
+
+
+@app.route('/v1/services/<id>/<revision>', methods=['PUT'])
+@authnz.require_auth
+@authnz.require_csrf_token
+@maintenance.check_maintenance_mode
+def revert_service_to_revision(id, revision):
+    try:
+        current_service = Service.get(id)
+        if current_service.data_type != 'service':
+            msg = 'id provided is not a service.'
+            return jsonify({'error': msg}), 400
+        new_revision = servicemanager.get_latest_service_revision(
+            id,
+            current_service.revision
+        )
+    except DoesNotExist:
+        logging.warning(
+            'Item with id {0} does not exist.'.format(id)
+        )
+        return jsonify({}), 404
+    try:
+        revert_service = Service.get('{}-{}'.format(id, revision))
+        if revert_service.data_type != 'archive-service':
+            msg = 'id provided is not a service.'
+            return jsonify({'error': msg}), 400
+    except DoesNotExist:
+        logging.warning(
+            'Item with id {0} does not exist.'.format(id)
+        )
+        return jsonify({}), 404
+    if revert_service.equals(current_service):
+        ret = {
+            'error': 'No difference between old and new service.'
+        }
+        return jsonify(ret), 400
+    if revert_service.credentials or revert_service.blind_credentials:
+        conflicts = credentialmanager.pair_key_conflicts_for_credentials(
+            revert_service.credentials,
+            revert_service.blind_credentials,
+        )
+        if conflicts:
+            ret = {
+                'error': 'Conflicting key pairs in mapped service.',
+                'conflicts': conflicts
+            }
+            return jsonify(ret), 400
+    # Try to save to the archive
+    try:
+        Service(
+            id='{0}-{1}'.format(id, new_revision),
+            data_type='archive-service',
+            credentials=revert_service.credentials,
+            blind_credentials=revert_service.blind_credentials,
+            account=revert_service.account,
+            enabled=revert_service.enabled,
+            revision=new_revision,
+            modified_by=authnz.get_logged_in_user()
+        ).save(id__null=True)
+    except PutError as e:
+        logging.error(e)
+        return jsonify({'error': 'Failed to add service to archive.'}), 500
+
+    try:
+        service = Service(
+            id=id,
+            data_type='service',
+            credentials=revert_service.credentials,
+            blind_credentials=revert_service.blind_credentials,
+            account=revert_service.account,
+            enabled=revert_service.enabled,
+            revision=new_revision,
+            modified_by=authnz.get_logged_in_user()
+        )
+        service.save()
+    except PutError as e:
+        logging.error(e)
+        return jsonify({'error': 'Failed to update active service.'}), 500
+    servicemanager.send_service_mapping_graphite_event(service, current_service)
+    webhook.send_event(
+        'service_update',
+        [service.id],
+        service.credentials,
+    )
+    credentials = credentialmanager.get_credentials(
+        service.credentials,
+        metadata_only=True,
+    )
+    blind_credentials = credentialmanager.get_blind_credentials(
+        service.blind_credentials,
+        metadata_only=True,
     )
     return jsonify({
         'id': service.id,


### PR DESCRIPTION
This change is aimed at returning less credential data, when that data is not necessary. Specifically, it's aiming to remove the return of full credential data when services are fetched through the interface, since those interfaces don't need the credential data.

Along with this change is a new method of doing reverts. I'm starting with service, because it's simpler, but future changes will also make this the method for credentials and blind_credentials, which will let us do reverts without needing to see values.