### PR TITLE
Cache iam role list using a background gevent thread

### DIFF
--- a/confidant/services/iamrolemanager.py
+++ b/confidant/services/iamrolemanager.py
@@ -1,0 +1,50 @@
+import gevent
+import logging
+import random
+
+import confidant.clients
+from confidant import settings
+
+ROLES = []
+
+
+def refresh_cache():
+    global ROLES
+    refresh_rate = settings.BACKGROUND_CACHE_IAM_ROLE_REFRESH_RATE
+    if settings.BACKGROUND_CACHE_IAM_ROLE_REFRESH_RATE < 60:
+        refresh_rate = 60
+    try:
+        logging.info('Refreshing IAM roles cache.')
+        ROLES = _get_iam_roles()
+    except Exception:
+        logging.exception(
+            'Failed to update IAM roles cache.',
+            exc_info=True
+        )
+    finally:
+        # +/- 20ish seconds for respawn, to ensure all processes do not
+        # refresh at the same time
+        random_refresh_rate = random.randrange(
+            refresh_rate - 20,
+            refresh_rate + 20
+        )
+        return gevent.spawn_later(
+            random_refresh_rate,
+            refresh_cache
+        )
+
+
+def get_iam_roles(purge=False):
+    if settings.BACKGROUND_CACHE_IAM_ROLES:
+        # If the cache is empty, assume it's not populated yet, and skip cache
+        if not ROLES:
+            return _get_iam_roles()
+        else:
+            return ROLES
+    else:
+        return _get_iam_roles()
+
+
+def _get_iam_roles():
+    iam_resource = confidant.clients.get_boto_resource('iam')
+    return [x.name for x in iam_resource.roles.all()]

--- a/confidant/settings.py
+++ b/confidant/settings.py
@@ -462,6 +462,18 @@ AWS_DEFAULT_REGION = str_env('AWS_DEFAULT_REGION', 'us-east-1')
 #
 # GEVENT_RESOLVER='ares'
 
+# IAM role cache configuration
+# Whether or not we keep a hot in-process cache of IAM roles, refreshed by a
+# gevent thread.
+BACKGROUND_CACHE_IAM_ROLES = bool_env('BACKGROUND_CACHE_IAM_ROLES', True)
+# Number of seconds between calls to refresh the IAM role cache. Calls will be
+# randomized +/- by 20s, to randomize calls across processes. Minimum value for
+# this setting is 60.
+BACKGROUND_CACHE_IAM_ROLE_REFRESH_RATE = int_env(
+    'BACKGROUND_CACHE_IAM_ROLE_REFRESH_RATE',
+    600
+)
+
 # Configuration validation
 _settings_failures = False
 if len(set(SCOPED_AUTH_KEYS.values())) != len(SCOPED_AUTH_KEYS.values()):

--- a/confidant/wsgi.py
+++ b/confidant/wsgi.py
@@ -2,6 +2,8 @@ import guard
 
 from confidant.app import app  # noqa
 from confidant import routes  # noqa
+from confidant import settings
+from confidant.services import iamrolemanager
 
 CSP_POLICY = {
     'default-src': ["'self'"],
@@ -12,3 +14,6 @@ CSP_POLICY = {
 }
 
 app.wsgi_app = guard.ContentSecurityPolicy(app.wsgi_app, CSP_POLICY)
+
+if settings.BACKGROUND_CACHE_IAM_ROLES:
+    iamrolemanager.refresh_cache()


### PR DESCRIPTION
In AWS accounts with a large number of IAM roles, the `get_iam_roles_list` endpoint is extremely slow, and can timeout. Also, we tend to call this frequently, and it's difficult to cache in the frontend.

This change caches the IAM role list in-process, and refreshes it on a refresh schedule, in the background.