### PR TITLE
Add a credential revert endpoint for credential history

### DIFF
--- a/confidant/models/credential.py
+++ b/confidant/models/credential.py
@@ -1,3 +1,4 @@
+import json
 from datetime import datetime
 
 from pynamodb.models import Model
@@ -14,6 +15,8 @@ from pynamodb.indexes import GlobalSecondaryIndex, AllProjection
 from confidant.app import app
 from confidant.models.session_cls import DDBSession
 from confidant.models.connection_cls import DDBConnection
+from confidant.services import keymanager
+from confidant.services.ciphermanager import CipherManager
 
 
 class DataTypeDateIndex(GlobalSecondaryIndex):
@@ -48,3 +51,32 @@ class Credential(Model):
     modified_date = UTCDateTimeAttribute(default=datetime.now)
     modified_by = UnicodeAttribute()
     documentation = UnicodeAttribute(null=True)
+
+    def equals(self, other_cred):
+        if self.name != other_cred.name:
+            return False
+        if self.decrypted_credential_pairs != other_cred.decrypted_credential_pairs:  # noqa:E501
+            return False
+        if self.metadata != other_cred.metadata:
+            return False
+        if self.enabled != other_cred.enabled:
+            return False
+        if self.documentation != other_cred.documentation:
+            return False
+        return True
+
+    @property
+    def decrypted_credential_pairs(self):
+        if self.data_type == 'credential':
+            context = self.id
+        else:
+            context = self.id.split('-')[0]
+        data_key = keymanager.decrypt_datakey(
+            self.data_key,
+            encryption_context={'id': context}
+        )
+        cipher_version = self.cipher_version
+        cipher = CipherManager(data_key, cipher_version)
+        _credential_pairs = cipher.decrypt(self.credential_pairs)
+        _credential_pairs = json.loads(_credential_pairs)
+        return _credential_pairs

--- a/confidant/public/modules/common/constants.js
+++ b/confidant/public/modules/common/constants.js
@@ -19,6 +19,7 @@
         ARCHIVE_SERVICES: 'v1/archive/services',
         ARCHIVE_SERVICE_REVISIONS: 'v1/archive/services/:id/:revision',
         CREDENTIAL: 'v1/credentials/:id',
+        CREDENTIAL_REVISION: 'v1/credentials/:id/:revision',
         CREDENTIAL_SERVICES: 'v1/credentials/:id/services',
         CREDENTIALS: 'v1/credentials',
         ARCHIVE_CREDENTIALS: 'v1/archive/credentials',

--- a/confidant/public/modules/history/controllers/CredentialHistoryCtrl.js
+++ b/confidant/public/modules/history/controllers/CredentialHistoryCtrl.js
@@ -79,15 +79,7 @@
 
             $scope.revertToDiffRevision = function() {
                 var deferred = $q.defer();
-                if (angular.equals($scope.diffCredential.name, $scope.currentCredential.name) &&
-                    angular.equals($scope.diffCredential.credential_pairs, $scope.currentCredential.credential_pairs) &&
-                    angular.equals($scope.diffCredential.metadata, $scope.currentCredential.metadata) &&
-                    angular.equals($scope.diffCredential.enabled, $scope.currentCredential.enabled)) {
-                    $scope.saveError = 'Can not revert to revision ' + $scope.diffCredential.revision + '. No difference between it and current revision.';
-                    deferred.reject();
-                    return deferred.promise;
-                }
-                Credential.update({'id': $scope.credentialId}, $scope.diffCredential).$promise.then(function(newCredential) {
+                Credential.revert({'id': $scope.credentialId, revision: $scope.diffCredential.revision}).$promise.then(function(newCredential) {
                     deferred.resolve();
                     ResourceArchiveService.updateResourceArchive();
                     $location.path('/history/credential/' + newCredential.id + '-' + newCredential.revision);

--- a/confidant/public/modules/resources/services/credentials.js
+++ b/confidant/public/modules/resources/services/credentials.js
@@ -18,8 +18,9 @@
     }])
 
     .factory('credentials.credential', ['$resource', 'CONFIDANT_URLS', function($resource, CONFIDANT_URLS) {
-        return $resource(CONFIDANT_URLS.CREDENTIAL, {id: '@id'}, {
-            update: {method: 'PUT', isArray: false}
+        return $resource(CONFIDANT_URLS.CREDENTIAL, {id: '@id', revision: '@revision'}, {
+            update: {method: 'PUT', isArray: false},
+            revert: {method: 'PUT', isArray: false, url: CONFIDANT_URLS.CREDENTIAL_REVISION}
         });
     }])
 


### PR DESCRIPTION
To make it possible to revert in the history view without needing full access to the decrypted credential pairs, this change adds a revert-to-revision endpoint, and updates the history view to use that endpoint.