### PR TITLE
Support ACLs for get_credential in the UI

### DIFF
--- a/confidant/public/modules/resources/controllers/CredentialDetailsCtrl.js
+++ b/confidant/public/modules/resources/controllers/CredentialDetailsCtrl.js
@@ -45,7 +45,12 @@
             var credentialCopy = null;
             $scope.$log = $log;
             $scope.saveError = '';
+            $scope.getError = '';
             $scope.credentialPairConflicts = null;
+            $scope.hasMetadata = false;
+            $scope.hasView = false;
+            // TODO: get this from the credential return
+            $scope.hasModify = true;
 
             if ($stateParams.credentialId) {
                 CredentialServices.get({'id': $stateParams.credentialId}).$promise.then(function(credentialServices) {
@@ -55,10 +60,16 @@
                 Credential.get({'id': $stateParams.credentialId}).$promise.then(function(credential) {
                     var _credentialPairs = [],
                         _metadata = [];
-                    angular.forEach(credential.credential_pairs, function(value, key) {
-                        this.push({'key': key, 'value': value});
-                    }, _credentialPairs);
-                    credential.credentialPairs = _credentialPairs;
+                    if (credential.credential_pairs) {
+                        angular.forEach(credential.credential_pairs, function(value, key) {
+                            this.push({'key': key, 'value': value});
+                        }, _credentialPairs);
+                        credential.credentialPairs = _credentialPairs;
+                        $scope.hasView = true;
+                    }
+                    if (credential.credential_keys) {
+                        $scope.hasMetadata = true;
+                    }
                     angular.forEach(credential.metadata, function(value, key) {
                         this.push({'key': key, 'value': value});
                     }, _metadata);
@@ -67,6 +78,14 @@
                     $scope.credential = credential;
                     credentialCopy = angular.copy($scope.credential);
                     $scope.shown = false;
+                }, function(res) {
+                    if (res.status === 500) {
+                        $scope.getError = 'Unexpected server error.';
+                        $log.error(res);
+                    } else {
+                        $scope.getError = res.data.error;
+                    }
+                    deferred.reject();
                 });
             } else {
                 $scope.credential = {

--- a/confidant/public/modules/resources/views/credential-details.html
+++ b/confidant/public/modules/resources/views/credential-details.html
@@ -28,7 +28,10 @@
   <p>Please ensure credential pair keys are unique for the mapped services, then try again.</p>
 </div>
 </div>
-<div class="well">
+<div class="alert alert-warning" ng-show="getError">
+<p>{{ getError }}</p>
+</div>
+<div class="well" ng-hide="getError">
   <form editable-form name="editableForm" onaftersave="saveCredential()" oncancel="cancel()" shown="{{ shown }}">
     <div class="form-group">
       <label for="credentialNameInput">Credential Name</label>
@@ -38,7 +41,17 @@
       <label for="credentialEnabled">Credential Enabled</label>
       <span editable-checkbox="credential.enabled" id="credentialEnabled">{{ credential.enabled }}</span>
     </div>
-    <div class="form-group">
+    <div class="form-group" ng-show="credential.id && hasMetadata && !hasView">
+      <label for="credentialKeys">Credential Keys</label>
+          <div class="well well-sm">
+              <ul id="credential.credential_keys" class="list-unstyled">
+                  <li ng-repeat="credentialKey in credential.credential_keys">
+                      {{ credentialKey }}
+                  </li>
+              </ul>
+        </div>
+    </div>
+    <div class="form-group" ng-show="hasView">
       <label for="credentialPairInputs">Credential Pairs <span class="glyphicon glyphicon-lock"></span></label>
       <div class="well well-sm" id="credentialPairInputs">
         <div class="row has-margin-bottom-lg">
@@ -148,7 +161,7 @@
     </div>
 
     <div class="buttons has-margin-bottom-lg">
-      <button type="button" class="btn btn-default" ng-click="editableForm.$show()" ng-show="!editableForm.$visible">Edit</button>
+      <button type="button" class="btn btn-default" ng-click="editableForm.$show()" ng-hide="editableForm.$visible || !hasModify">Edit</button>
       <span ng-show="editableForm.$visible">
         <button type="submit" class="btn" ng-disabled="editableForm.$waiting">Save</button>
         <button type="button" class="btn btn-alternate" ng-disabled="editableForm.$waiting" ng-click="editableForm.$cancel()">Cancel</button>


### PR DESCRIPTION
This change adds basic support for ACLs in the backend for get_credential. Right now the rights on the credential are assumed based on what's returned. Modify is always set true because of this. Ideally we'll update the backend to return a list of rights, which can provide hints to the frontend.