### PR TITLE
Paging for history view

### DIFF
--- a/confidant/public/modules/history/controllers/BlindCredentialHistoryCtrl.js
+++ b/confidant/public/modules/history/controllers/BlindCredentialHistoryCtrl.js
@@ -69,14 +69,6 @@
                 }
             });
 
-            $scope.getCredentialByID = function(id) {
-                return $filter('filter')($scope.$parent.credentialList, {'id': id})[0];
-            };
-
-            $scope.getBlindCredentialByID = function(id) {
-                return $filter('filter')($scope.$parent.blindCredentialList, {'id': id})[0];
-            };
-
             $scope.revertToDiffRevision = function() {
                 var deferred = $q.defer();
                 BlindCredential.revert({'id': $scope.blindCredentialId, 'revision': $scope.diffBlindCredential.revision}).$promise.then(function(newBlindCredential) {

--- a/confidant/public/modules/history/controllers/BlindCredentialHistoryCtrl.js
+++ b/confidant/public/modules/history/controllers/BlindCredentialHistoryCtrl.js
@@ -73,8 +73,8 @@
                 var deferred = $q.defer();
                 BlindCredential.revert({'id': $scope.blindCredentialId, 'revision': $scope.diffBlindCredential.revision}).$promise.then(function(newBlindCredential) {
                     deferred.resolve();
-                    ResourceArchiveService.updateResourceArchive();
-                    $location.path('/history/blind_credential/' + newBlindCredential.id + '-' + newBlindCredential.revision);
+                    ResourceArchiveService.updateResourceArchive('blind_credentials');
+                    $location.path('/history/blind_credentials/' + newBlindCredential.id + '-' + newBlindCredential.revision);
                 }, function(res) {
                     if (res.status === 500) {
                         $scope.saveError = 'Unexpected server error.';

--- a/confidant/public/modules/history/controllers/CredentialHistoryCtrl.js
+++ b/confidant/public/modules/history/controllers/CredentialHistoryCtrl.js
@@ -62,14 +62,6 @@
                 }
             });
 
-            $scope.getCredentialByID = function(id, revision) {
-                return $filter('filter')($scope.$parent.credentialList, {'id': id, 'revision': revision})[0];
-            };
-
-            $scope.getBlindCredentialByID = function(id, revision) {
-                return $filter('filter')($scope.$parent.blindCredentialList, {'id': id, 'revision': revision})[0];
-            };
-
             $scope.isString = function(value) {
                 return angular.isString(value);
             };

--- a/confidant/public/modules/history/controllers/CredentialHistoryCtrl.js
+++ b/confidant/public/modules/history/controllers/CredentialHistoryCtrl.js
@@ -44,7 +44,7 @@
                 } else {
                     if ($scope.credentialRevision === $scope.currentRevision) {
                         $scope.diffRevision = $scope.currentRevision - 1;
-                        $location.path('/history/credential/' + $scope.credentialId + '-' + $scope.diffRevision);
+                        $location.path('/history/credentials/' + $scope.credentialId + '-' + $scope.diffRevision);
                     } else {
                         $scope.diffRevision = $scope.credentialRevision;
                     }
@@ -70,8 +70,8 @@
                 var deferred = $q.defer();
                 Credential.revert({'id': $scope.credentialId, revision: $scope.diffRevision}).$promise.then(function(newCredential) {
                     deferred.resolve();
-                    ResourceArchiveService.updateResourceArchive();
-                    $location.path('/history/credential/' + newCredential.id + '-' + newCredential.revision);
+                    ResourceArchiveService.updateResourceArchive('credentials');
+                    $location.path('/history/credentials/' + newCredential.id + '-' + newCredential.revision);
                 }, function(res) {
                     if (res.status === 500) {
                         $scope.saveError = 'Unexpected server error.';

--- a/confidant/public/modules/history/controllers/ResourceHistoryCtrl.js
+++ b/confidant/public/modules/history/controllers/ResourceHistoryCtrl.js
@@ -15,10 +15,11 @@
         '$log',
         '$timeout',
         '$location',
+        '$filter',
         'credentials.list',
         'blindcredentials.list',
         'history.ResourceArchiveService',
-        function ($scope, $log, $timeout, $location, CredentialList, BlindCredentialList, ResourceArchiveService) {
+        function ($scope, $log, $timeout, $location, $filter, CredentialList, BlindCredentialList, ResourceArchiveService) {
             $scope.typeFilter = 'credentials';
 
             CredentialList.get().$promise.then(function(credentialList) {

--- a/confidant/public/modules/history/controllers/ResourceHistoryCtrl.js
+++ b/confidant/public/modules/history/controllers/ResourceHistoryCtrl.js
@@ -19,7 +19,7 @@
         'blindcredentials.list',
         'history.ResourceArchiveService',
         function ($scope, $log, $timeout, $location, CredentialList, BlindCredentialList, ResourceArchiveService) {
-            $scope.typeFilter = 'credential';
+            $scope.typeFilter = 'credentials';
 
             CredentialList.get().$promise.then(function(credentialList) {
                 $scope.credentialList = credentialList.credentials;
@@ -68,13 +68,7 @@
             };
 
             $scope.gotoResource = function(resource) {
-                if (resource.type === 'credential') {
-                    $location.path('/history/credential/' + resource.id);
-                } else if (resource.type === 'blind_credential') {
-                    $location.path('/history/blind_credential/' + resource.id);
-                } else if (resource.type === 'service') {
-                    $location.path('/history/service/' + resource.id);
-                }
+                $location.path('/history/' + resource.type + '/' + resource.id);
             };
 
 
@@ -82,9 +76,10 @@
             $scope.hasNext = ResourceArchiveService.hasNext;
             $scope.fetchMoreResourceArchive = ResourceArchiveService.fetchMoreResourceArchive;
             $scope.getResourceArchive = ResourceArchiveService.getResourceArchive;
-            $scope.$watch('getResourceArchive()', function(newResourceArchive, oldResourceArchive) {
-                if(newResourceArchive !== oldResourceArchive) {
-                    $scope.resourceArchive = newResourceArchive;
+            $scope.getResourceArchiveVersion = ResourceArchiveService.getResourceArchiveVersion;
+            $scope.$watch('getResourceArchiveVersion()', function(newVersion, oldVersion) {
+                if(newVersion !== oldVersion) {
+                    $scope.resourceArchive = ResourceArchiveService.getResourceArchive();
                 }
             });
             // TODO: There's a race condition here, for some reason. We need to figure out how to
@@ -94,13 +89,17 @@
             if (angular.isUndefined($scope.clientconfig)) {
                 $timeout(function() {
                     ResourceArchiveService.setLimit($scope.clientconfig.generated.history_page_limit);
-                    ResourceArchiveService.updateResourceArchive();
+                    ResourceArchiveService.initResourceArchive('credentials');
+                    ResourceArchiveService.initResourceArchive('blind_credentials');
+                    ResourceArchiveService.initResourceArchive('services');
                 }, 1000);
             } else {
                 // When moving between resources and history, the client config already exists, so we
                 // can avoid the timeout.
                 ResourceArchiveService.setLimit($scope.clientconfig.generated.history_page_limit);
-                ResourceArchiveService.updateResourceArchive();
+                ResourceArchiveService.initResourceArchive('credentials');
+                ResourceArchiveService.initResourceArchive('blind_credentials');
+                ResourceArchiveService.initResourceArchive('services');
             }
 
         }])

--- a/confidant/public/modules/history/controllers/ResourceHistoryCtrl.js
+++ b/confidant/public/modules/history/controllers/ResourceHistoryCtrl.js
@@ -13,14 +13,13 @@
     .controller('history.ResourceHistoryCtrl', [
         '$scope',
         '$log',
+        '$timeout',
         '$location',
         'credentials.list',
         'blindcredentials.list',
         'history.ResourceArchiveService',
-        function ($scope, $log, $location, CredentialList, BlindCredentialList, ResourceArchiveService) {
-            $scope.showCredentials = true;
-            $scope.showBlindCredentials = true;
-            $scope.showServices = true;
+        function ($scope, $log, $timeout, $location, CredentialList, BlindCredentialList, ResourceArchiveService) {
+            $scope.typeFilter = 'credential';
 
             CredentialList.get().$promise.then(function(credentialList) {
                 $scope.credentialList = credentialList.credentials;
@@ -33,6 +32,14 @@
             }, function() {
                 $scope.blindCredentialList = [];
             });
+
+            $scope.getCredentialByID = function(id) {
+                return $filter('filter')($scope.credentialList, {'id': id})[0];
+            };
+
+            $scope.getBlindCredentialByID = function(id) {
+                return $filter('filter')($scope.blindCredentialList, {'id': id})[0];
+            };
 
             // Reformat archive credential IDs for display. Archive credential IDs
             // are formatted as id-revision.
@@ -49,15 +56,15 @@
 
             $scope.resourceTypeFilter = function(field) {
                 return function(resource) {
-                    if (resource[field] === 'credential' && $scope.showCredentials) {
-                        return true;
-                    } else if (resource[field] === 'blind_credential' && $scope.showBlindCredentials) {
-                        return true;
-                    } else if (resource[field] === 'service' && $scope.showServices) {
+                    if (resource[field] === $scope.typeFilter) {
                         return true;
                     }
                     return false;
                 };
+            };
+
+            $scope.setTypeFilter = function(type) {
+                $scope.typeFilter = type;
             };
 
             $scope.gotoResource = function(resource) {
@@ -70,14 +77,31 @@
                 }
             };
 
+
             $scope.$log = $log;
+            $scope.hasNext = ResourceArchiveService.hasNext;
+            $scope.fetchMoreResourceArchive = ResourceArchiveService.fetchMoreResourceArchive;
             $scope.getResourceArchive = ResourceArchiveService.getResourceArchive;
             $scope.$watch('getResourceArchive()', function(newResourceArchive, oldResourceArchive) {
                 if(newResourceArchive !== oldResourceArchive) {
                     $scope.resourceArchive = newResourceArchive;
                 }
             });
-            ResourceArchiveService.updateResourceArchive();
+            // TODO: There's a race condition here, for some reason. We need to figure out how to
+            // wait until the clientconfig is loaded before calling this. For now we're using a gross
+            // timeout hack. client_config endpoint is fast, so it's very likely it'll be loaded within
+            // the time period
+            if (angular.isUndefined($scope.clientconfig)) {
+                $timeout(function() {
+                    ResourceArchiveService.setLimit($scope.clientconfig.generated.history_page_limit);
+                    ResourceArchiveService.updateResourceArchive();
+                }, 1000);
+            } else {
+                // When moving between resources and history, the client config already exists, so we
+                // can avoid the timeout.
+                ResourceArchiveService.setLimit($scope.clientconfig.generated.history_page_limit);
+                ResourceArchiveService.updateResourceArchive();
+            }
 
         }])
 

--- a/confidant/public/modules/history/controllers/ServiceHistoryCtrl.js
+++ b/confidant/public/modules/history/controllers/ServiceHistoryCtrl.js
@@ -45,14 +45,6 @@
                 }
             });
 
-            $scope.getCredentialByID = function(id) {
-                return $filter('filter')($scope.$parent.credentialList, {'id': id})[0];
-            };
-
-            $scope.getBlindCredentialByID = function(id) {
-                return $filter('filter')($scope.$parent.blindCredentialList, {'id': id})[0];
-            };
-
             $scope.getServiceByRevision = function(rev) {
                 return $filter('filter')($scope.revisions, {revision: rev})[0];
             };

--- a/confidant/public/modules/history/controllers/ServiceHistoryCtrl.js
+++ b/confidant/public/modules/history/controllers/ServiceHistoryCtrl.js
@@ -75,8 +75,8 @@
                 var deferred = $q.defer();
                 Service.revert({'id': $scope.serviceId, revision: $scope.diffRevision}).$promise.then(function(newService) {
                     deferred.resolve();
-                    ResourceArchiveService.updateResourceArchive();
-                    $location.path('/history/service/' + newService.id + '-' + newService.revision);
+                    ResourceArchiveService.updateResourceArchive('services');
+                    $location.path('/history/services/' + newService.id + '-' + newService.revision);
                 }, function(res) {
                     if (res.status === 500) {
                         $scope.saveError = 'Unexpected server error.';

--- a/confidant/public/modules/history/services/archive.js
+++ b/confidant/public/modules/history/services/archive.js
@@ -44,8 +44,8 @@
             function doQuery(service, page, limit) {
                 limit = limit || _this.limit;
                 page = page || null;
-                var defer = $q.defer(),
-                    result = service.get({'page': page, 'limit': limit}).$promise.then(function(result) {
+                var defer = $q.defer();
+                service.get({'page': page, 'limit': limit}).$promise.then(function(result) {
                     defer.resolve(result);
                 });
                 return defer.promise;
@@ -64,9 +64,9 @@
             }
 
             function queryUntilItem(service, type, item, data, page, count) {
-                data = data || []
-                page = page || null
-                count = count || 0
+                data = data || [];
+                page = page || null;
+                count = count || 0;
                 var max = 10,
                     defer = $q.defer();
 
@@ -120,8 +120,7 @@
 
             this.updateResourceArchive = function(type) {
                 var archive = _this.resourceArchive[type],
-                    latestItem = archive.archive[0],
-                    newData = [];
+                    latestItem = archive.archive[0];
                 queryUntilItem(archive.service, type, latestItem).then(function(newData) {
                     mungeResourceData(newData, type);
                     archive.archive = newData.concat(archive.archive);

--- a/confidant/public/modules/history/services/archive.js
+++ b/confidant/public/modules/history/services/archive.js
@@ -15,13 +15,43 @@
         'blindcredentials.archiveList',
         'services.archiveList',
         function($q, CredentialArchive, BlindCredentialArchive, ServiceArchive) {
-            function doQuery(service) {
-                var d = $q.defer(),
-                    result = service.get(function() { d.resolve(result); });
-                return d.promise;
-            }
             var _this = this;
             this.resourceArchive = [];
+            this.credentialArchive = [];
+            this.nextCredentialPage = null;
+            this.blindCredentialArchive = [];
+            this.nextBlindCredentialPage = null;
+            this.serviceArchive = [];
+            this.nextServicePage = null;
+            this.limit = 1;
+
+            function doQuery(service, page, limit) {
+                limit = limit || _this.limit;
+                page = page || null;
+                return service.get({'page': page, 'limit': limit}).$promise.then(function(result) { return result; });
+            }
+
+            function concatArchives() {
+                _this.resourceArchive = _this.credentialArchive
+                    .concat(_this.blindCredentialArchive)
+                    .concat(_this.serviceArchive);
+            }
+
+            function mungeResourceData(data, dataType) {
+                data.forEach(function(resource){
+                    resource.type = dataType;
+                    resource.modified_date = new Date(resource.modified_date);
+                    if (dataType === 'service') {
+                        // For consistency, everything has a name, so we'll set the service name from its ID.
+                        // The ID is name-revision, so we need to split and take the first item.
+                        resource.name = resource.id.split('-')[0];
+                    }
+                });
+            }
+
+            this.setLimit = function(limit) {
+                _this.limit = limit;
+            };
 
             this.updateResourceArchive = function() {
                 var credentialArchivePromise = doQuery(CredentialArchive),
@@ -31,30 +61,96 @@
                     var credentialArchive = results[0].credentials,
                         blindCredentialArchive = results[1].blind_credentials,
                         serviceArchive = results[2].services;
-                    for (var i = credentialArchive.length; i--;) {
-                        credentialArchive[i].type = 'credential';
+                    // We fetched each archive without a page set. We're either initializing them for the view,
+                    // or a change has occurred and we're fetching data and pushing it onto the top of the archives.
+                    // Initialization is occurring if the archive is empty. If we're pushing data on the top,
+                    // we need to ensure we fetch all new data, or we'll be missing data in the view. For that we'll
+                    // need to page until we hit the first record of the archive.
+                    mungeResourceData(credentialArchive, 'credential');
+                    if (_this.credentialArchive.length === 0) {
+                        _this.credentialArchive = credentialArchive;
+                        _this.nextCredentialPage = results[0].next_page;
+                    } else {
+                        // TODO: take top item in this.credentialArchive, find the index in the fetched
+                        // version and splice them together at that point. If it's not found, fetch another
+                        // page of the credentials.
                     }
-                    for (i = blindCredentialArchive.length; i--;) {
-                        blindCredentialArchive[i].type = 'blind_credential';
+                    mungeResourceData(blindCredentialArchive, 'blind_credential');
+                    if (_this.blindCredentialArchive.length === 0) {
+                        _this.blindCredentialArchive = blindCredentialArchive;
+                        _this.nextBlindCredentialPage = results[1].next_page;
+                    } else {
+                        // TODO: take top item in this.blindCredentialArchive, find the index in the fetched
+                        // version and splice them together at that point. If it's not found, fetch another
+                        // page of the blind credentials.
                     }
-                    for (i = serviceArchive.length; i--;) {
-                        serviceArchive[i].type = 'service';
-                        var nameArr = serviceArchive[i].id.split('-');
-                        nameArr.pop();
-                        serviceArchive[i].name = nameArr.join('-');
+                    mungeResourceData(serviceArchive, 'service');
+                    if (_this.serviceArchive.length === 0) {
+                        _this.serviceArchive = serviceArchive;
+                        _this.nextServicePage = results[2].next_page;
+                    } else {
+                        // TODO: take top item in this.serviceArchive, find the index in the fetched
+                        // version and splice them together at that point. If it's not found, fetch another
+                        // page of the services.
                     }
-                    _this.resourceArchive = credentialArchive.concat(blindCredentialArchive);
-                    _this.resourceArchive = _this.resourceArchive.concat(serviceArchive);
-                    _this.resourceArchive.forEach(function(resource){
-                        resource.modified_date = new Date(resource.modified_date);
-                    });
+                    concatArchives();
                 }, function() {
+                    // TODO: setting the resourceArchive to an empty array here will cause problems if
+                    // any update fails, so we should probably have some way of indicating a failure,
+                    // rather than setting it to an empty array.
                     _this.resourceArchive = [];
+                });
+            };
+
+            this.fetchMoreResourceArchive = function() {
+                var promises = [];
+                if (_this.nextCredentialPage !== null) {
+                    promises.push(doQuery(CredentialArchive, _this.nextCredentialPage));
+                }
+                if (_this.nextBlindCredentialPage !== null) {
+                    promises.push(doQuery(BlindCredentialArchive, _this.nextBlindCredentialPage));
+                }
+                if (_this.nextServicePage !== null) {
+                    promises.push(doQuery(ServiceArchive, _this.nextServicePage));
+                }
+                $q.all(promises).then(function(results) {
+                    var credentialArchive = [],
+                        blindCredentialArchive = [],
+                        serviceArchive = [];
+                    for (var i = results.length; i--;) {
+                        if (angular.isDefined(results[i].credentials)) {
+                            credentialArchive = results[i].credentials;
+                            _this.nextCredentialPage = results[i].next_page;
+                        } else if (angular.isDefined(results[i].blind_credentials)) {
+                            blindCredentialArchive = results[i].blind_credentials;
+                            _this.nextBlindCredentialPage = results[i].next_page;
+                        } else if (angular.isDefined(results[i].services)) {
+                            serviceArchive = results[i].services;
+                            _this.nextServicePage = results[i].next_page;
+                        }
+                    }
+                    mungeResourceData(credentialArchive, 'credential');
+                    _this.credentialArchive = _this.credentialArchive.concat(credentialArchive);
+                    mungeResourceData(blindCredentialArchive, 'blind_credential');
+                    _this.blindCredentialArchive = _this.blindCredentialArchive.concat(blindCredentialArchive);
+                    mungeResourceData(serviceArchive, 'service');
+                    _this.serviceArchive = _this.serviceArchive.concat(serviceArchive);
+                    concatArchives();
                 });
             };
 
             this.getResourceArchive = function() {
                 return _this.resourceArchive;
+            };
+
+            this.hasNext = function(type) {
+                if (type === 'credential') {
+                    return _this.nextCredentialPage !== null;
+                } else if (type === 'blind-credential') {
+                    return _this.nextBlindCredentialPage !== null;
+                } else if (type === 'service') {
+                    return _this.nextServicePage !== null;
+                }
             };
 
     }])

--- a/confidant/public/modules/history/views/blind-credential-history.html
+++ b/confidant/public/modules/history/views/blind-credential-history.html
@@ -1,5 +1,32 @@
 <div class="alert alert-warning" ng-show="saveError">
 <p>{{ saveError }}</p>
+<div ng-show="credentialPairConflicts">
+  <p>The following credential pair keys conflict in the listed credentials in the listed mapped services:</p>
+  <ul>
+    <li ng-repeat="(credentialPairKey, conflicts) in credentialPairConflicts">
+      {{ credentialPairKey }}:
+      <ul>
+        <li>Credentials:</li>
+        <ul>
+          <li ng-repeat="credentialId in conflicts.credentials"><a class="color-text-snow" href="#/resources/credential/{{ credentialId }}">{{ parent.getCredentialByID(credentialId).name }}</a></li>
+        </ul>
+      </ul>
+      <ul>
+        <li>Blind credentials:</li>
+        <ul>
+          <li ng-repeat="credentialId in conflicts.blind_credentials"><a class="color-text-snow" href="#/resources/blind_credential/{{ credentialId }}">{{ parent.getBlindCredentialByID(credentialId).name }}</a></li>
+        </ul>
+      </ul>
+      <ul>
+        <li>Services:</li>
+        <ul>
+          <li ng-repeat="serviceId in conflicts.services"><a class="color-text-snow" href="#/resources/service/{{ serviceId }}">{{ serviceId }}</a></li>
+        </ul>
+      </ul>
+    </li>
+  </ul>
+  <p>Please ensure credential pair keys are unique for the mapped services, then try again.</p>
+</div>
 </div>
 <div class="well">
   <h3 class="has-margin-bottom-lg">Difference between revisions of {{ currentBlindCredential.name }}</h3>

--- a/confidant/public/modules/history/views/blind-credential-history.html
+++ b/confidant/public/modules/history/views/blind-credential-history.html
@@ -31,8 +31,8 @@
 <div class="well">
   <h3 class="has-margin-bottom-lg">Difference between revisions of {{ currentBlindCredential.name }}</h3>
   <div class="row">
-    <a ng-show="blindCredentialRevision > 1" style="float: left" class="has-margin-bottom-lg" href="#/history/blind_credential/{{ blindCredentialId }}-{{ blindCredentialRevision - 1 }}"><span class="glyphicon glyphicon-menu-left"></span> previous revision</a>
-    <a ng-show="blindCredentialRevision < currentRevision" style="float: right" class="has-margin-bottom-lg" href="#/history/blind_credential/{{ blindCredentialId }}-{{ blindCredentialRevision + 1 }}">next revision <span class="glyphicon glyphicon-menu-right"></span></a>
+    <a ng-show="blindCredentialRevision > 1" style="float: left" class="has-margin-bottom-lg" href="#/history/blind_credentials/{{ blindCredentialId }}-{{ blindCredentialRevision - 1 }}"><span class="glyphicon glyphicon-menu-left"></span> previous revision</a>
+    <a ng-show="blindCredentialRevision < currentRevision" style="float: right" class="has-margin-bottom-lg" href="#/history/blind_credentials/{{ blindCredentialId }}-{{ blindCredentialRevision + 1 }}">next revision <span class="glyphicon glyphicon-menu-right"></span></a>
   </div>
   <div class="row">
     <div class="col-md-6">

--- a/confidant/public/modules/history/views/credential-history.html
+++ b/confidant/public/modules/history/views/credential-history.html
@@ -38,8 +38,8 @@
 <div class="well" ng-hide="isOnlyRevision || !hasDiff">
   <h3 class="has-margin-bottom-lg">Difference between revisions of {{ currentCredential.name }}</h3>
   <div class="row">
-    <a ng-show="credentialRevision > 1" style="float: left" class="has-margin-bottom-lg" href="#/history/credential/{{ credentialId }}-{{ credentialRevision - 1 }}"><span class="glyphicon glyphicon-menu-left"></span> previous revision</a>
-    <a ng-show="credentialRevision < currentRevision - 1" style="float: right" class="has-margin-bottom-lg" href="#/history/credential/{{ credentialId }}-{{ credentialRevision + 1 }}">next revision <span class="glyphicon glyphicon-menu-right"></span></a>
+    <a ng-show="credentialRevision > 1" style="float: left" class="has-margin-bottom-lg" href="#/history/credentials/{{ credentialId }}-{{ credentialRevision - 1 }}"><span class="glyphicon glyphicon-menu-left"></span> previous revision</a>
+    <a ng-show="credentialRevision < currentRevision - 1" style="float: right" class="has-margin-bottom-lg" href="#/history/credentials/{{ credentialId }}-{{ credentialRevision + 1 }}">next revision <span class="glyphicon glyphicon-menu-right"></span></a>
   </div>
   <div ng-show="noDiff">
     <p>No difference between revisions {{ diffRevision }} and {{ currentRevision }} for {{ currentCredential.name }}</p>

--- a/confidant/public/modules/history/views/credential-history.html
+++ b/confidant/public/modules/history/views/credential-history.html
@@ -1,19 +1,31 @@
 <div class="alert alert-warning" ng-show="saveError">
 <p>{{ saveError }}</p>
 <div ng-show="credentialPairConflicts">
-  <p>The following credential pair keys conflict in the listed credentials:</p>
+  <p>The following credential pair keys conflict in the listed credentials in the listed mapped services:</p>
   <ul>
     <li ng-repeat="(credentialPairKey, conflicts) in credentialPairConflicts">
       {{ credentialPairKey }}:
       <ul>
         <li>Credentials:</li>
         <ul>
-          <li ng-repeat="credentialId in conflicts.credentials"><a class="color-text-snow" href="#/resources/credential/{{ credentialId }}">{{ getCredentialByID(credentialId).name }}</a></li>
+          <li ng-repeat="credentialId in conflicts.credentials"><a class="color-text-snow" href="#/resources/credential/{{ credentialId }}">{{ parent.getCredentialByID(credentialId).name }}</a></li>
+        </ul>
+      </ul>
+      <ul>
+        <li>Blind credentials:</li>
+        <ul>
+          <li ng-repeat="credentialId in conflicts.blind_credentials"><a class="color-text-snow" href="#/resources/blind_credential/{{ credentialId }}">{{ parent.getBlindCredentialByID(credentialId).name }}</a></li>
+        </ul>
+      </ul>
+      <ul>
+        <li>Services:</li>
+        <ul>
+          <li ng-repeat="serviceId in conflicts.services"><a class="color-text-snow" href="#/resources/service/{{ serviceId }}">{{ serviceId }}</a></li>
         </ul>
       </ul>
     </li>
   </ul>
-  <p>Please ensure credential pair keys are unique, then try again.</p>
+  <p>Please ensure credential pair keys are unique for the mapped services, then try again.</p>
 </div>
 </div>
 <div class="alert alert-warning" ng-show="getError">

--- a/confidant/public/modules/history/views/resources.html
+++ b/confidant/public/modules/history/views/resources.html
@@ -3,16 +3,16 @@
     <div class="row">
       <div class="form">
         <div class="form-group col-md-12">
-          <input type="search" class="form-control" data-ng-model="resourceRegex" placeholder="filter (credential or service name)">
+          <input type="search" class="form-control" data-ng-model="resourceRegex" placeholder="filter (credential, blind credential, or service name)">
         </div>
       </div>
     </div>
     <div class="row has-margin-bottom-lg">
       <div class="form">
         <div class="simple-form col-md-12">
-          <button type="button" ng-class="{ 'history-active': typeFilter == 'credential' }" ng-click="setTypeFilter('credential')" class="btn">Credentials</button>
-          <button type="button" ng-class="{ 'history-active': typeFilter == 'blind-credential' }" ng-click="setTypeFilter('blind-credential')" class="btn">Blind Credentials</button>
-          <button type="button" ng-class="{ 'history-active': typeFilter == 'service' }" ng-click="setTypeFilter('service')" class="btn">Services</button>
+          <button type="button" ng-class="{ 'history-active': typeFilter == 'credentials' }" ng-click="setTypeFilter('credentials')" class="btn">Credentials</button>
+          <button type="button" ng-class="{ 'history-active': typeFilter == 'blind_credentials' }" ng-click="setTypeFilter('blind_credentials')" class="btn">Blind Credentials</button>
+          <button type="button" ng-class="{ 'history-active': typeFilter == 'services' }" ng-click="setTypeFilter('services')" class="btn">Services</button>
         </div>
       </div>
     </div>
@@ -28,7 +28,7 @@
             </tr>
           </thead>
           <tbody>
-            <tr ng-repeat="resource in resourceArchive | filter: resourceRegexFilter('name', resourceRegex) | filter: resourceTypeFilter('type') | orderBy:'-modified_date'" ng-click="gotoResource(resource)" style="cursor: pointer">
+            <tr ng-repeat="resource in resourceArchive[typeFilter].archive | filter: resourceRegexFilter('name', resourceRegex) | orderBy:'-modified_date'" ng-click="gotoResource(resource)" style="cursor: pointer">
               <td>{{ resource.type }}</td>
               <td class="dont-break-out">{{ resource.name }}</td>
               <td>{{ resource.revision }}</td>
@@ -36,9 +36,9 @@
             </tr>
           </tbody>
         </table>
-        <button type="button" ng-show="typeFilter == 'credential' && hasNext('credential')" ng-click="fetchMoreResourceArchive()" class="btn pull-center">Load more credentials...</button>
-        <button type="button" ng-show="typeFilter == 'blind-credential' && hasNext('blind-credential')" ng-click="fetchMoreResourceArchive()" class="btn pull-center">Load more blind credentials...</button>
-        <button type="button" ng-show="typeFilter == 'service' && hasNext('service')" ng-click="fetchMoreResourceArchive()" class="btn pull-center">Load more services...</button>
+        <button type="button" ng-show="typeFilter == 'credentials' && hasNext(typeFilter)" ng-click="fetchMoreResourceArchive(typeFilter)" class="btn pull-center">Load more credentials...</button>
+        <button type="button" ng-show="typeFilter == 'blind_credentials' && hasNext(typeFilter)" ng-click="fetchMoreResourceArchive(typeFilter)" class="btn pull-center">Load more blind credentials...</button>
+        <button type="button" ng-show="typeFilter == 'services' && hasNext(typeFilter)" ng-click="fetchMoreResourceArchive(typeFilter)" class="btn pull-center">Load more services...</button>
       </div>
     </div>
   </div>

--- a/confidant/public/modules/history/views/resources.html
+++ b/confidant/public/modules/history/views/resources.html
@@ -10,9 +10,9 @@
     <div class="row has-margin-bottom-lg">
       <div class="form">
         <div class="simple-form col-md-12">
-          <label for="showCredentials"><input id="showCredentials" type="checkbox" data-ng-model="showCredentials" /> Credentials&nbsp;</label>
-          <label for="showBlindCredentials"><input id="showBlindCredentials" type="checkbox" data-ng-model="showBlindCredentials" /> Blind Credentials&nbsp;</label>
-          <label for="showServices"><input id="showServices" type="checkbox" data-ng-model="showServices" /> Services</label>
+          <button type="button" ng-class="{ 'history-active': typeFilter == 'credential' }" ng-click="setTypeFilter('credential')" class="btn">Credentials</button>
+          <button type="button" ng-class="{ 'history-active': typeFilter == 'blind-credential' }" ng-click="setTypeFilter('blind-credential')" class="btn">Blind Credentials</button>
+          <button type="button" ng-class="{ 'history-active': typeFilter == 'service' }" ng-click="setTypeFilter('service')" class="btn">Services</button>
         </div>
       </div>
     </div>
@@ -33,8 +33,12 @@
               <td class="dont-break-out">{{ resource.name }}</td>
               <td>{{ resource.revision }}</td>
               <td>{{ resource.modified_date | date:'medium':'GMT' }} GMT</td>
+            </tr>
           </tbody>
         </table>
+        <button type="button" ng-show="typeFilter == 'credential' && hasNext('credential')" ng-click="fetchMoreResourceArchive()" class="btn pull-center">Load more credentials...</button>
+        <button type="button" ng-show="typeFilter == 'blind-credential' && hasNext('blind-credential')" ng-click="fetchMoreResourceArchive()" class="btn pull-center">Load more blind credentials...</button>
+        <button type="button" ng-show="typeFilter == 'service' && hasNext('service')" ng-click="fetchMoreResourceArchive()" class="btn pull-center">Load more services...</button>
       </div>
     </div>
   </div>

--- a/confidant/public/modules/history/views/service-history.html
+++ b/confidant/public/modules/history/views/service-history.html
@@ -31,8 +31,8 @@
 <div class="well">
   <h3 class="has-margin-bottom-lg">Difference between revisions of {{ serviceId }}</h3>
   <div class="row">
-    <a ng-show="serviceRevision > 1" style="float: left" class="has-margin-bottom-lg" href="#/history/service/{{ serviceId }}-{{ serviceRevision - 1 }}"><span class="glyphicon glyphicon-menu-left"></span> previous revision</a>
-    <a ng-show="serviceRevision < currentRevision" style="float: right" class="has-margin-bottom-lg" href="#/history/service/{{ serviceId }}-{{ serviceRevision + 1 }}">next revision <span class="glyphicon glyphicon-menu-right"></span></a>
+    <a ng-show="serviceRevision > 1" style="float: left" class="has-margin-bottom-lg" href="#/history/services/{{ serviceId }}-{{ serviceRevision - 1 }}"><span class="glyphicon glyphicon-menu-left"></span> previous revision</a>
+    <a ng-show="serviceRevision < currentRevision" style="float: right" class="has-margin-bottom-lg" href="#/history/services/{{ serviceId }}-{{ serviceRevision + 1 }}">next revision <span class="glyphicon glyphicon-menu-right"></span></a>
   </div>
   <div class="row">
     <div class="col-md-6">

--- a/confidant/public/modules/history/views/service-history.html
+++ b/confidant/public/modules/history/views/service-history.html
@@ -1,19 +1,31 @@
 <div class="alert alert-warning" ng-show="saveError">
 <p>{{ saveError }}</p>
 <div ng-show="credentialPairConflicts">
-  <p>The following credential pair keys conflict in the listed credentials:</p>
+  <p>The following credential pair keys conflict in the listed credentials in the listed mapped services:</p>
   <ul>
     <li ng-repeat="(credentialPairKey, conflicts) in credentialPairConflicts">
       {{ credentialPairKey }}:
       <ul>
         <li>Credentials:</li>
         <ul>
-          <li ng-repeat="credentialId in conflicts.credentials"><a class="color-text-snow" href="#/resources/credential/{{ credentialId }}">{{ getCredentialByID(credentialId).name }}</a></li>
+          <li ng-repeat="credentialId in conflicts.credentials"><a class="color-text-snow" href="#/resources/credential/{{ credentialId }}">{{ parent.getCredentialByID(credentialId).name }}</a></li>
+        </ul>
+      </ul>
+      <ul>
+        <li>Blind credentials:</li>
+        <ul>
+          <li ng-repeat="credentialId in conflicts.blind_credentials"><a class="color-text-snow" href="#/resources/blind_credential/{{ credentialId }}">{{ parent.getBlindCredentialByID(credentialId).name }}</a></li>
+        </ul>
+      </ul>
+      <ul>
+        <li>Services:</li>
+        <ul>
+          <li ng-repeat="serviceId in conflicts.services"><a class="color-text-snow" href="#/resources/service/{{ serviceId }}">{{ serviceId }}</a></li>
         </ul>
       </ul>
     </li>
   </ul>
-  <p>Please ensure credential pair keys are unique, then try again.</p>
+  <p>Please ensure credential pair keys are unique for the mapped services, then try again.</p>
 </div>
 </div>
 <div class="well">

--- a/confidant/public/modules/resources/services/credentials.js
+++ b/confidant/public/modules/resources/services/credentials.js
@@ -14,7 +14,7 @@
     }])
 
     .factory('credentials.archiveList', ['$resource', 'CONFIDANT_URLS', function($resource, CONFIDANT_URLS) {
-        return $resource(CONFIDANT_URLS.ARCHIVE_CREDENTIALS);
+        return $resource(CONFIDANT_URLS.ARCHIVE_CREDENTIALS, {page: '@page', revision: '@revision'});
     }])
 
     .factory('credentials.credential', ['$resource', 'CONFIDANT_URLS', function($resource, CONFIDANT_URLS) {

--- a/confidant/public/modules/routes/history.js
+++ b/confidant/public/modules/routes/history.js
@@ -23,7 +23,7 @@
         })
 
         .state('history.credential-history', {
-            url: '/credential/:credentialId',
+            url: '/credentials/:credentialId',
             views: {
                 'details': {
                     controller: 'history.CredentialHistoryCtrl',
@@ -36,7 +36,7 @@
         })
 
         .state('history.blind-credential-history', {
-            url: '/blind_credential/:blindCredentialId',
+            url: '/blind_credentials/:blindCredentialId',
             views: {
                 'details': {
                     controller: 'history.BlindCredentialHistoryCtrl',
@@ -49,7 +49,7 @@
         })
 
         .state('history.service-history', {
-            url: '/service/:serviceId',
+            url: '/services/:serviceId',
             views: {
                 'details': {
                     controller: 'history.ServiceHistoryCtrl',

--- a/confidant/public/styles/main.css
+++ b/confidant/public/styles/main.css
@@ -142,6 +142,10 @@ body {
   content: "+ ";
 }
 
+.history-active {
+  color: #337ab7;
+}
+
 /*
  * Loading spinner
  */

--- a/confidant/routes/v1.py
+++ b/confidant/routes/v1.py
@@ -56,12 +56,13 @@ def get_client_config():
     '''
     # TODO: add more config in here.
     response = jsonify({
-        'defined': app.config['CLIENT_CONFIG'],
+        'defined': settings.CLIENT_CONFIG,
         'generated': {
-            'kms_auth_manage_grants': app.config['KMS_AUTH_MANAGE_GRANTS'],
-            'aws_accounts': list(app.config['SCOPED_AUTH_KEYS'].values()),
-            'xsrf_cookie_name': app.config['XSRF_COOKIE_NAME'],
-            'maintenance_mode': app.config['MAINTENANCE_MODE']
+            'kms_auth_manage_grants': settings.KMS_AUTH_MANAGE_GRANTS,
+            'aws_accounts': list(settings.SCOPED_AUTH_KEYS.values()),
+            'xsrf_cookie_name': settings.XSRF_COOKIE_NAME,
+            'maintenance_mode': settings.MAINTENANCE_MODE,
+            'history_page_limit': settings.HISTORY_PAGE_LIMIT,
         }
     })
     return response
@@ -191,9 +192,19 @@ def get_archive_service_revisions(id):
 @app.route('/v1/archive/services', methods=['GET'])
 @authnz.require_auth
 def get_archive_service_list():
+    limit = request.args.get(
+        'limit',
+        default=settings.HISTORY_PAGE_LIMIT,
+        type=int,
+    )
+    page = request.args.get('page', default=None, type=str)
     services = []
     for service in Service.data_type_date_index.query(
-            'archive-service', scan_index_forward=False):
+        'archive-service',
+        scan_index_forward=False,
+        limit=limit,
+        last_evaluated_key=page,
+    ):
         services.append({
             'id': service.id,
             'account': service.account,
@@ -573,9 +584,19 @@ def get_archive_credential_revisions(id):
 @app.route('/v1/archive/credentials', methods=['GET'])
 @authnz.require_auth
 def get_archive_credential_list():
+    limit = request.args.get(
+        'limit',
+        default=settings.HISTORY_PAGE_LIMIT,
+        type=int,
+    )
+    page = request.args.get('page', default=None, type=str)
     credentials = []
     for cred in Credential.data_type_date_index.query(
-            'archive-credential', scan_index_forward=False):
+        'archive-credential',
+        scan_index_forward=False,
+        limit=limit,
+        last_evaluated_key=page,
+    ):
         credentials.append({
             'id': cred.id,
             'name': cred.name,
@@ -995,9 +1016,19 @@ def get_archive_blind_credential_revisions(id):
 @app.route('/v1/archive/blind_credentials', methods=['GET'])
 @authnz.require_auth
 def get_archive_blind_credential_list():
+    limit = request.args.get(
+        'limit',
+        default=settings.HISTORY_PAGE_LIMIT,
+        type=int,
+    )
+    page = request.args.get('page', default=None, type=str)
     blind_credentials = []
     for cred in BlindCredential.data_type_date_index.query(
-            'archive-blind-credential', scan_index_forward=False):
+        'archive-blind-credential',
+        scan_index_forward=False,
+        limit=limit,
+        last_evaluated_key=page,
+    ):
         blind_credentials.append({
             'id': cred.id,
             'name': cred.name,

--- a/confidant/routes/v1.py
+++ b/confidant/routes/v1.py
@@ -20,6 +20,10 @@ from confidant.services import credentialmanager
 from confidant.services import servicemanager
 from confidant.services.ciphermanager import CipherManager
 from confidant.utils import maintenance
+from confidant.utils.dynamodb import (
+    decode_last_evaluated_key,
+    encode_last_evaluated_key,
+)
 from confidant.models.credential import Credential
 from confidant.models.blind_credential import BlindCredential
 from confidant.models.service import Service
@@ -198,13 +202,20 @@ def get_archive_service_list():
         type=int,
     )
     page = request.args.get('page', default=None, type=str)
+    if page:
+        try:
+            page = decode_last_evaluated_key(page)
+        except Exception:
+            logging.exception('Failed to parse provided page')
+            return jsonify({'error': 'Failed to parse page'}), 400
     services = []
-    for service in Service.data_type_date_index.query(
+    results = Service.data_type_date_index.query(
         'archive-service',
         scan_index_forward=False,
         limit=limit,
         last_evaluated_key=page,
-    ):
+    )
+    for service in results:
         services.append({
             'id': service.id,
             'account': service.account,
@@ -214,7 +225,11 @@ def get_archive_service_list():
             'modified_date': service.modified_date,
             'modified_by': service.modified_by
         })
-    return jsonify({'services': services})
+    service_list = {'services': services}
+    service_list['next_page'] = encode_last_evaluated_key(
+        results.last_evaluated_key
+    )
+    return jsonify(service_list)
 
 
 @app.route('/v1/grants/<id>', methods=['PUT'])
@@ -566,6 +581,7 @@ def get_archive_credential_revisions(id):
         revisions.append({
             'id': revision.id,
             'name': revision.name,
+            'metadata': cred.metadata,
             'revision': revision.revision,
             'enabled': revision.enabled,
             'modified_date': revision.modified_date,
@@ -590,23 +606,35 @@ def get_archive_credential_list():
         type=int,
     )
     page = request.args.get('page', default=None, type=str)
+    if page:
+        try:
+            page = decode_last_evaluated_key(page)
+        except Exception:
+            logging.exception('Failed to parse provided page')
+            return jsonify({'error': 'Failed to parse page'}), 400
     credentials = []
-    for cred in Credential.data_type_date_index.query(
+    results = Credential.data_type_date_index.query(
         'archive-credential',
         scan_index_forward=False,
         limit=limit,
         last_evaluated_key=page,
-    ):
+    )
+    for cred in results:
         credentials.append({
             'id': cred.id,
             'name': cred.name,
+            'metadata': cred.metadata,
             'revision': cred.revision,
             'enabled': cred.enabled,
             'modified_date': cred.modified_date,
             'modified_by': cred.modified_by,
             'documentation': cred.documentation
         })
-    return jsonify({'credentials': credentials})
+    credential_list = {'credentials': credentials}
+    credential_list['next_page'] = encode_last_evaluated_key(
+        results.last_evaluated_key
+    )
+    return jsonify(credential_list)
 
 
 @app.route('/v1/credentials', methods=['POST'])
@@ -912,8 +940,6 @@ def revert_credential_to_revision(id, to_revision):
     return jsonify({
         'id': cred.id,
         'name': cred.name,
-        'credential_pairs': cred.decrypted_credential_pairs,
-        'credential_keys': cred.credential_keys,
         'metadata': cred.metadata,
         'revision': cred.revision,
         'enabled': cred.enabled,
@@ -1022,13 +1048,20 @@ def get_archive_blind_credential_list():
         type=int,
     )
     page = request.args.get('page', default=None, type=str)
+    if page:
+        try:
+            page = decode_last_evaluated_key(page)
+        except Exception:
+            logging.exception('Failed to parse provided page')
+            return jsonify({'error': 'Failed to parse page'}), 400
     blind_credentials = []
-    for cred in BlindCredential.data_type_date_index.query(
+    results = BlindCredential.data_type_date_index.query(
         'archive-blind-credential',
         scan_index_forward=False,
         limit=limit,
         last_evaluated_key=page,
-    ):
+    )
+    for cred in results:
         blind_credentials.append({
             'id': cred.id,
             'name': cred.name,
@@ -1044,7 +1077,11 @@ def get_archive_blind_credential_list():
             'modified_by': cred.modified_by,
             'documentation': cred.documentation
         })
-    return jsonify({'blind_credentials': blind_credentials})
+    credential_list = {'blind_credentials': blind_credentials}
+    credential_list['next_page'] = encode_last_evaluated_key(
+        results.last_evaluated_key
+    )
+    return jsonify(credential_list)
 
 
 @app.route('/v1/blind_credentials', methods=['POST'])

--- a/confidant/settings.py
+++ b/confidant/settings.py
@@ -331,6 +331,8 @@ DYNAMODB_CREATE_TABLE = bool_env('DYNAMODB_CREATE_TABLE', False)
 # Connection pool size for PynamoDB connections to DynamoDB
 PYNAMO_CONNECTION_POOL_SIZE = int_env('PYNAMO_CONNECTION_POOL_SIZE', 100)
 PYNAMO_REQUEST_TIMEOUT_SECONDS = int_env('PYNAMO_REQUEST_TIMEOUT_SECONDS', 1)
+# page limit size for history API endpoints listing
+HISTORY_PAGE_LIMIT = int_env('HISTORY_PAGE_LIMIT')
 
 # Encryption
 

--- a/confidant/utils/dynamodb.py
+++ b/confidant/utils/dynamodb.py
@@ -1,3 +1,5 @@
+import base64
+import json
 import time
 
 from pynamodb.exceptions import TableError
@@ -34,3 +36,16 @@ def create_dynamodb_tables():
         except TableError:
             i = i + 1
             time.sleep(2)
+
+
+def encode_last_evaluated_key(last_evaluated_key):
+    if not last_evaluated_key:
+        return None
+    str_key = json.dumps(last_evaluated_key)
+    return base64.b64encode(str_key.encode('UTF-8')).decode('UTF-8')
+
+
+def decode_last_evaluated_key(last_evaluated_key):
+    if not last_evaluated_key:
+        return None
+    return json.loads(base64.b64decode(last_evaluated_key))

--- a/confidant/wsgi.py
+++ b/confidant/wsgi.py
@@ -1,3 +1,4 @@
+import gevent
 import guard
 
 from confidant.app import app  # noqa
@@ -16,4 +17,4 @@ CSP_POLICY = {
 app.wsgi_app = guard.ContentSecurityPolicy(app.wsgi_app, CSP_POLICY)
 
 if settings.BACKGROUND_CACHE_IAM_ROLES:
-    iamrolemanager.refresh_cache()
+    gevent.spawn(iamrolemanager.refresh_cache)


### PR DESCRIPTION
This change refactors the history view to support paging, and also to update the history list efficiently when a resource is reverted.

A new setting `HISTORY_PAGE_LIMIT` is added. By default it isn't set, keeping the original behavior of the endpoints, and the UI. Setting a limit will limit the number of results the revision history endpoints will return. They'll also return a next_page attribute along with the results, which can be passed in for the next set of results. This value is also exposed to the UI via the `get_client_config endpoint`, and is accessible in the angular code via `$scope.clientconfig.generated.history_page_limit`.

The history UI no longer shows a combined history with checkboxes to filter in/out credentials, blind_credentials and services, but instead shows a navigation list for each. The reasoning for this is that loading in pages items would not show the interleaved history accurately, as each type is being fetched separately, and each may be edited at different frequencies. Splitting them out also makes it possible to fetch them individually through the "Load more" button.

The initial fetch of the history does a fetch of each type, but the default for the view is credential history.

