### PR TITLE
Refactor resources view to match history view for resource toggling

### DIFF
--- a/confidant/public/modules/app.js
+++ b/confidant/public/modules/app.js
@@ -22,8 +22,12 @@
      * Main controller
      */
     .controller('ConfidantMainCtrl', [
-        '$scope', '$http', 'common.userinfo', 'common.clientconfig',
-        function ConfidantMainCtrl($scope, $http, userinfo, clientconfig) {
+        '$scope', '$http', 'common.userinfo', 'common.clientconfig', '$log', '$transitions',
+        function ConfidantMainCtrl($scope, $http, userinfo, clientconfig, $log, $transitions) {
+
+        $transitions.onSuccess({}, function(transition) {
+          $scope.viewLocation = transition.to().data.viewLocation;
+        });
 
         $scope.user = userinfo.get();
         clientconfig.get().$promise.then(function(clientConfig) {

--- a/confidant/public/modules/history/views/blind-credential-history.html
+++ b/confidant/public/modules/history/views/blind-credential-history.html
@@ -8,19 +8,19 @@
       <ul>
         <li>Credentials:</li>
         <ul>
-          <li ng-repeat="credentialId in conflicts.credentials"><a class="color-text-snow" href="#/resources/credential/{{ credentialId }}">{{ parent.getCredentialByID(credentialId).name }}</a></li>
+          <li ng-repeat="credentialId in conflicts.credentials"><a class="color-text-snow" href="#/resources/credentials/{{ credentialId }}">{{ parent.getCredentialByID(credentialId).name }}</a></li>
         </ul>
       </ul>
       <ul>
         <li>Blind credentials:</li>
         <ul>
-          <li ng-repeat="credentialId in conflicts.blind_credentials"><a class="color-text-snow" href="#/resources/blind_credential/{{ credentialId }}">{{ parent.getBlindCredentialByID(credentialId).name }}</a></li>
+          <li ng-repeat="credentialId in conflicts.blind_credentials"><a class="color-text-snow" href="#/resources/blind_credentials/{{ credentialId }}">{{ parent.getBlindCredentialByID(credentialId).name }}</a></li>
         </ul>
       </ul>
       <ul>
         <li>Services:</li>
         <ul>
-          <li ng-repeat="serviceId in conflicts.services"><a class="color-text-snow" href="#/resources/service/{{ serviceId }}">{{ serviceId }}</a></li>
+          <li ng-repeat="serviceId in conflicts.services"><a class="color-text-snow" href="#/resources/services/{{ serviceId }}">{{ serviceId }}</a></li>
         </ul>
       </ul>
     </li>
@@ -136,13 +136,13 @@
     </div>
   </div>
   <div ng-show="isCurrentRevision">
-    <p ng-show="isOnlyRevision">This is the only revision of this blind credential. You'll need to <a href="#/resources/blind_credential/{{ blindCredentialId }}">edit the blind credential</a> to make any changes.</p>
+    <p ng-show="isOnlyRevision">This is the only revision of this blind credential. You'll need to <a href="#/resources/blind_credentials/{{ blindCredentialId }}">edit the blind credential</a> to make any changes.</p>
     <div ng-hide="isOnlyRevision">
       <p class="has-margin-bottom-lg">This is the current revision of this blind credential. The above diff is between the current revision and the previous revision.</p>
-      <button class="btn" ng-click="revertToDiffRevision()">Revert to revision {{ diffRevision }}</button>
+      <button class="btn call-to-action" ng-click="revertToDiffRevision()">Revert to revision {{ diffRevision }}</button>
     </div>
   </div>
   <div ng-hide="isCurrentRevision">
-    <button class="btn" ng-click="revertToDiffRevision()">Revert to revision {{ diffRevision }}</button>
+    <button class="btn call-to-action" ng-click="revertToDiffRevision()">Revert to revision {{ diffRevision }}</button>
   </div>
 </div>

--- a/confidant/public/modules/history/views/credential-history.html
+++ b/confidant/public/modules/history/views/credential-history.html
@@ -8,19 +8,19 @@
       <ul>
         <li>Credentials:</li>
         <ul>
-          <li ng-repeat="credentialId in conflicts.credentials"><a class="color-text-snow" href="#/resources/credential/{{ credentialId }}">{{ parent.getCredentialByID(credentialId).name }}</a></li>
+          <li ng-repeat="credentialId in conflicts.credentials"><a class="color-text-snow" href="#/resources/credentials/{{ credentialId }}">{{ parent.getCredentialByID(credentialId).name }}</a></li>
         </ul>
       </ul>
       <ul>
         <li>Blind credentials:</li>
         <ul>
-          <li ng-repeat="credentialId in conflicts.blind_credentials"><a class="color-text-snow" href="#/resources/blind_credential/{{ credentialId }}">{{ parent.getBlindCredentialByID(credentialId).name }}</a></li>
+          <li ng-repeat="credentialId in conflicts.blind_credentials"><a class="color-text-snow" href="#/resources/blind_credentials/{{ credentialId }}">{{ parent.getBlindCredentialByID(credentialId).name }}</a></li>
         </ul>
       </ul>
       <ul>
         <li>Services:</li>
         <ul>
-          <li ng-repeat="serviceId in conflicts.services"><a class="color-text-snow" href="#/resources/service/{{ serviceId }}">{{ serviceId }}</a></li>
+          <li ng-repeat="serviceId in conflicts.services"><a class="color-text-snow" href="#/resources/services/{{ serviceId }}">{{ serviceId }}</a></li>
         </ul>
       </ul>
     </li>
@@ -33,7 +33,7 @@
 </div>
 <div class="well" ng-show="isOnlyRevision">
   <h3 class="has-margin-bottom-lg">Only revision of {{ currentCredential.name }}</h3>
-  <p ng-show="isOnlyRevision">This is the only revision of this credential. You'll need to <a href="#/resources/credential/{{ credentialId }}">edit the credential</a> to make any changes.</p>
+  <p ng-show="isOnlyRevision">This is the only revision of this credential. You'll need to <a href="#/resources/credentials/{{ credentialId }}">edit the credential</a> to make any changes.</p>
 </div>
 <div class="well" ng-hide="isOnlyRevision || !hasDiff">
   <h3 class="has-margin-bottom-lg">Difference between revisions of {{ currentCredential.name }}</h3>
@@ -74,7 +74,7 @@
     </div>
   </div>
   <div ng-hide="isCurrentRevision">
-    <button class="btn" ng-click="revertToDiffRevision()">Revert to revision {{ diffRevision }}</button>
+    <button class="btn call-to-action" ng-click="revertToDiffRevision()">Revert to revision {{ diffRevision }}</button>
   </div>
   <div>
 </div>

--- a/confidant/public/modules/history/views/resources.html
+++ b/confidant/public/modules/history/views/resources.html
@@ -10,9 +10,9 @@
     <div class="row has-margin-bottom-lg">
       <div class="form">
         <div class="simple-form col-md-12">
-          <button type="button" ng-class="{ 'history-active': typeFilter == 'credentials' }" ng-click="setTypeFilter('credentials')" class="btn">Credentials</button>
-          <button type="button" ng-class="{ 'history-active': typeFilter == 'blind_credentials' }" ng-click="setTypeFilter('blind_credentials')" class="btn">Blind Credentials</button>
-          <button type="button" ng-class="{ 'history-active': typeFilter == 'services' }" ng-click="setTypeFilter('services')" class="btn">Services</button>
+          <button type="button" ng-class="{ 'active': typeFilter == 'credentials' }" ng-click="setTypeFilter('credentials')" class="btn">Credentials</button>
+          <button type="button" ng-class="{ 'active': typeFilter == 'blind_credentials' }" ng-click="setTypeFilter('blind_credentials')" class="btn">Blind Credentials</button>
+          <button type="button" ng-class="{ 'active': typeFilter == 'services' }" ng-click="setTypeFilter('services')" class="btn">Services</button>
         </div>
       </div>
     </div>
@@ -21,18 +21,20 @@
         <table class="table table-hover">
           <thead>
             <tr>
-              <th>Type</th>
               <th>Name</th>
               <th>Revision</th>
               <th>Modified</th>
+              <th>Modified By</th>
+              <th></th>
             </tr>
           </thead>
           <tbody>
             <tr ng-repeat="resource in resourceArchive[typeFilter].archive | filter: resourceRegexFilter('name', resourceRegex) | orderBy:'-modified_date'" ng-click="gotoResource(resource)" style="cursor: pointer">
-              <td>{{ resource.type }}</td>
               <td class="dont-break-out">{{ resource.name }}</td>
               <td>{{ resource.revision }}</td>
               <td>{{ resource.modified_date | date:'medium':'GMT' }} GMT</td>
+              <td>{{ resource.modified_by }}</td>
+              <td><span class="glyphicon glyphicon-menu-right"></span></td>
             </tr>
           </tbody>
         </table>

--- a/confidant/public/modules/history/views/service-history.html
+++ b/confidant/public/modules/history/views/service-history.html
@@ -8,19 +8,19 @@
       <ul>
         <li>Credentials:</li>
         <ul>
-          <li ng-repeat="credentialId in conflicts.credentials"><a class="color-text-snow" href="#/resources/credential/{{ credentialId }}">{{ parent.getCredentialByID(credentialId).name }}</a></li>
+          <li ng-repeat="credentialId in conflicts.credentials"><a class="color-text-snow" href="#/resources/credentials/{{ credentialId }}">{{ parent.getCredentialByID(credentialId).name }}</a></li>
         </ul>
       </ul>
       <ul>
         <li>Blind credentials:</li>
         <ul>
-          <li ng-repeat="credentialId in conflicts.blind_credentials"><a class="color-text-snow" href="#/resources/blind_credential/{{ credentialId }}">{{ parent.getBlindCredentialByID(credentialId).name }}</a></li>
+          <li ng-repeat="credentialId in conflicts.blind_credentials"><a class="color-text-snow" href="#/resources/blind_credentials/{{ credentialId }}">{{ parent.getBlindCredentialByID(credentialId).name }}</a></li>
         </ul>
       </ul>
       <ul>
         <li>Services:</li>
         <ul>
-          <li ng-repeat="serviceId in conflicts.services"><a class="color-text-snow" href="#/resources/service/{{ serviceId }}">{{ serviceId }}</a></li>
+          <li ng-repeat="serviceId in conflicts.services"><a class="color-text-snow" href="#/resources/services/{{ serviceId }}">{{ serviceId }}</a></li>
         </ul>
       </ul>
     </li>
@@ -80,13 +80,13 @@
     </div>
   </div>
   <div ng-show="isCurrentRevision">
-    <p ng-show="isOnlyRevision">This is the only revision of this service. You'll need to <a href="#/resources/service/{{ serviceId }}">edit the service</a> to make any changes.</p>
+    <p ng-show="isOnlyRevision">This is the only revision of this service. You'll need to <a href="#/resources/services/{{ serviceId }}">edit the service</a> to make any changes.</p>
     <div ng-hide="isOnlyRevision">
       <p class="has-margin-bottom-lg">This is the current revision of this service. The above diff is between the current revision and the previous revision.</p>
-      <button class="btn" ng-click="revertToDiffRevision()">Revert to revision {{ diffRevision }}</button>
+      <button class="btn call-to-action" ng-click="revertToDiffRevision()">Revert to revision {{ diffRevision }}</button>
     </div>
   </div>
   <div ng-hide="isCurrentRevision">
-    <button class="btn" ng-click="revertToDiffRevision()">Revert to revision {{ diffRevision }}</button>
+    <button class="btn call-to-action" ng-click="revertToDiffRevision()">Revert to revision {{ diffRevision }}</button>
   </div>
 </div>

--- a/confidant/public/modules/resources/controllers/CredentialDetailsCtrl.js
+++ b/confidant/public/modules/resources/controllers/CredentialDetailsCtrl.js
@@ -252,7 +252,7 @@
                     Credentials.create(_credential).$promise.then(function(newCredential) {
                         $scope.$emit('updateCredentialList');
                         deferred.resolve();
-                        $location.path('/resources/credential/' + newCredential.id);
+                        $location.path('/resources/credentials/' + newCredential.id);
                     }, function(res) {
                         if (res.status === 500) {
                             $scope.saveError = 'Unexpected server error.';

--- a/confidant/public/modules/resources/controllers/ResourceCtrl.js
+++ b/confidant/public/modules/resources/controllers/ResourceCtrl.js
@@ -13,12 +13,14 @@
         '$scope',
         '$stateParams',
         '$q',
+        '$location',
         '$log',
         'credentials.CredentialListService',
         'blindcredentials.BlindCredentialListService',
         'services.ServiceListService',
-        function ($scope, $stateParams, $q, $log, CredentialListService, BlindCredentialListService, ServiceListService) {
+        function ($scope, $stateParams, $q, $location, $log, CredentialListService, BlindCredentialListService, ServiceListService) {
             $scope.$log = $log;
+            $scope.typeFilter = 'credentials';
             $scope.showDisabled = false;
 
             $scope.getCredentialList = CredentialListService.getCredentialList;
@@ -45,6 +47,10 @@
             });
             $scope.$emit('updateServiceList');
 
+            $scope.setTypeFilter = function(type) {
+                $scope.typeFilter = type;
+            };
+
             $scope.resourceRegexFilter = function(field, regex) {
                 return function(resource) {
                     var pattern = new RegExp(regex, 'ig');
@@ -52,21 +58,17 @@
                 };
             };
 
-            $scope.resourceTypeFilter = function(field) {
-                return function() {
-                    if (field === 'credential' && $scope.showCredential) {
-                        return true;
-                    } else if (field === 'blind-credential' && $scope.showBlindCredential) {
-                        return true;
-                    } else if (field === 'service' && $scope.showService) {
-                        return true;
-                    }
-                    return false;
-                };
+            $scope.gotoResource = function(resource, type) {
+                $location.path('/resources/' + type + '/' + resource.id);
             };
 
-        }])
+            $scope.showResource = function(resource) {
+                if (resource.enabled || $scope.showDisabled) {
+                    return true;
+                }
+                return false;
+            };
 
-    ;
+        }]);
 
 })(window.angular);

--- a/confidant/public/modules/resources/controllers/ServiceDetailsCtrl.js
+++ b/confidant/public/modules/resources/controllers/ServiceDetailsCtrl.js
@@ -244,7 +244,7 @@
                     serviceCopy = angular.copy($scope.service);
                     deferred.resolve();
                     if ($scope.newService) {
-                        $location.path('/resources/service/' + newService.id);
+                        $location.path('/resources/services/' + newService.id);
                     }
                 }, function(res) {
                     if (res.status === 500) {

--- a/confidant/public/modules/resources/views/blind-credential-details.html
+++ b/confidant/public/modules/resources/views/blind-credential-details.html
@@ -57,7 +57,7 @@
     </div>
     <div class="form-group" ng-show="blindCredential.id">
       <label for="blindCredentialRevision">Blind Credential Revision</label>
-      <span id="blindCredentialRevision">{{ blindCredential.revision }}</span>
+      <span id="blindCredentialRevision">{{ blindCredential.revision }} (<a href="#/history/blind_credentials/{{ blindCredential.id }}-{{ blindCredential.revision }}">view history</a>)</span>
     </div>
     <div class="form-group" ng-show="blindCredential.id">
       <label for="blindCredentialDocumentation">Blind Credential Rotation Documentation</label>
@@ -68,7 +68,7 @@
           <div class="well well-sm">
               <ul id="blindCredentialServices" class="list-unstyled">
                   <li ng-repeat="blindCredentialService in blindCredentialServices">
-                      <a href="#/resources/service/{{ blindCredentialService.id }}">{{ blindCredentialService.id }}</a> <span ng-hide="blindCredentialService.enabled">(disabled)</span>
+                      <a href="#/resources/services/{{ blindCredentialService.id }}">{{ blindCredentialService.id }}</a> <span ng-hide="blindCredentialService.enabled">(disabled)</span>
                   </li>
               </ul>
         </div>

--- a/confidant/public/modules/resources/views/credential-details.html
+++ b/confidant/public/modules/resources/views/credential-details.html
@@ -8,19 +8,19 @@
       <ul>
         <li>Credentials:</li>
         <ul>
-          <li ng-repeat="credentialId in conflicts.credentials"><a class="color-text-snow" href="#/resources/credential/{{ credentialId }}">{{ getCredentialByID(credentialId).name }}</a></li>
+          <li ng-repeat="credentialId in conflicts.credentials"><a class="color-text-snow" href="#/resources/credentials/{{ credentialId }}">{{ getCredentialByID(credentialId).name }}</a></li>
         </ul>
       </ul>
       <ul>
         <li>Blind credentials:</li>
         <ul>
-          <li ng-repeat="credentialId in conflicts.blind_credentials"><a class="color-text-snow" href="#/resources/blind_credential/{{ credentialId }}">{{ getBlindCredentialByID(credentialId).name }}</a></li>
+          <li ng-repeat="credentialId in conflicts.blind_credentials"><a class="color-text-snow" href="#/resources/blind_credentials/{{ credentialId }}">{{ getBlindCredentialByID(credentialId).name }}</a></li>
         </ul>
       </ul>
       <ul>
         <li>Services:</li>
         <ul>
-          <li ng-repeat="serviceId in conflicts.services"><a class="color-text-snow" href="#/resources/service/{{ serviceId }}">{{ serviceId }}</a></li>
+          <li ng-repeat="serviceId in conflicts.services"><a class="color-text-snow" href="#/resources/services/{{ serviceId }}">{{ serviceId }}</a></li>
         </ul>
       </ul>
     </li>
@@ -147,23 +147,23 @@
     </div>
     <div class="form-group" ng-show="credential.id">
       <label for="credentialRevision">Credential Revision</label>
-      <span id="credentialRevision">{{ credential.revision }}</span>
+      <span id="credentialRevision">{{ credential.revision }} (<a href="#/history/credentials/{{ credential.id }}-{{ credential.revision }}">view history</a>)</span>
     </div>
     <div class="form-group" ng-show="credential.id">
       <label for="credentialServices">Services Using This Credential</label>
           <div class="well well-sm">
               <ul id="credentialServices" class="list-unstyled">
                   <li ng-repeat="credentialService in credentialServices">
-                      <a href="#/resources/service/{{ credentialService.id }}">{{ credentialService.id }}</a> <span ng-hide="credentialService.enabled">(disabled)</span>
+                      <a href="#/resources/services/{{ credentialService.id }}">{{ credentialService.id }}</a> <span ng-hide="credentialService.enabled">(disabled)</span>
                   </li>
               </ul>
         </div>
     </div>
 
     <div class="buttons has-margin-bottom-lg">
-      <button type="button" class="btn btn-default" ng-click="editableForm.$show()" ng-hide="editableForm.$visible || !hasModify">Edit</button>
+      <button type="button" class="btn btn-default call-to-action" ng-click="editableForm.$show()" ng-hide="editableForm.$visible || !hasModify">Edit</button>
       <span ng-show="editableForm.$visible">
-        <button type="submit" class="btn" ng-disabled="editableForm.$waiting">Save</button>
+        <button type="submit" class="btn call-to-action" ng-disabled="editableForm.$waiting">Save</button>
         <button type="button" class="btn btn-alternate" ng-disabled="editableForm.$waiting" ng-click="editableForm.$cancel()">Cancel</button>
       </span>
     </div>

--- a/confidant/public/modules/resources/views/resources.html
+++ b/confidant/public/modules/resources/views/resources.html
@@ -1,17 +1,24 @@
 <div class="row row-relative">
-  <div class="col-md-4 well row-relative">
+  <div class="col-md-5 well row-relative">
     <div class="row">
       <div class="form">
-        <div class="form-group col-md-9">
-          <input type="search" class="form-control" data-ng-model="resourceRegex" placeholder="filter (credential or service name)" />
+        <div class="form-group col-md-12">
+          <input type="search" class="form-control" data-ng-model="resourceRegex" placeholder="filter (credential, blind-credential, or service name)" />
         </div>
-        <div class="btn-group col-md-3 dropdown">
-          <button type="button" class="btn dropdown-toggle" data-toggle="dropdown" aria-expanded="false"><span class="glyphicon glyphicon-plus"> <small><span class="glyphicon glyphicon-chevron-down glyphicon-xs"></span></small></span></button>
-          <ul class="dropdown-menu" role="menu">
-            <li><a href="#/resources/new/credential">Create credential</a></li>
-            <li><a href="#/resources/new/service">Create service</a></li>
-          </ul>
-        </div>
+      </div>
+    </div>
+    <div class="row has-margin-bottom-lg">
+      <div class="col-md-9">
+        <button type="button" ng-class="{ 'active': typeFilter == 'credentials' }" ng-click="setTypeFilter('credentials')" class="btn">Credentials</button>
+        <button type="button" ng-class="{ 'active': typeFilter == 'blind_credentials' }" ng-click="setTypeFilter('blind_credentials')" class="btn">Blind Credentials</button>
+        <button type="button" ng-class="{ 'active': typeFilter == 'services' }" ng-click="setTypeFilter('services')" class="btn">Services</button>
+      </div>
+      <div class="btn-group dropdown col-md-3">
+        <button type="button" class="btn dropdown-toggle call-to-action" data-toggle="dropdown" aria-expanded="false">Create <span class="glyphicon glyphicon-chevron-down glyphicon-xs"></span></small></span></button>
+        <ul class="dropdown-menu" role="menu">
+          <li><a href="#/resources/new/credential">Create credential</a></li>
+          <li><a href="#/resources/new/service">Create service</a></li>
+        </ul>
       </div>
     </div>
     <div class="row has-margin-bottom-lg">
@@ -22,38 +29,45 @@
       </div>
     </div>
     <div class="row row-overflow-resources">
-      <div class="col-md-12">
-        <div class="panel panel-default">
-          <div class="panel-heading">Credentials</div>
-          <div ng-hide="credentialList" class="panel-body">No credentials.</div>
-          <div class="list-group" ng-show="credentialList">
-            <div ng-repeat="cred in credentialList | filter: resourceRegexFilter('name', resourceRegex)" ng-show="cred.enabled || showDisabled">
-                <a href="#/resources/credential/{{ cred.id }}" class="dont-break-out list-group-item"><span class="glyphicon glyphicon-menu-right pull-right"></span><p class="list-group-item-heading">{{ cred.name }}</p></span></a>
-            </div>
-          </div>
-        </div>
-        <div class="panel panel-default">
-          <div class="panel-heading">Blind Credentials</div>
-          <div ng-hide="blindCredentialList" class="panel-body">No blind credentials.</div>
-          <div class="list-group" ng-show="blindCredentialList">
-            <div ng-repeat="cred in blindCredentialList | filter: resourceRegexFilter('name', resourceRegex)" ng-show="cred.enabled || showDisabled">
-                <a href="#/resources/blind_credential/{{ cred.id }}" class="dont-break-out list-group-item"><span class="glyphicon glyphicon-menu-right pull-right"></span><p class="list-group-item-heading">{{ cred.name }}</p></span></a>
-            </div>
-          </div>
-        </div>
-        <div class="panel panel-default">
-          <div class="panel-heading">Services</div>
-          <div ng-hide="serviceList" class="panel-body">No services.</div>
-          <div class="list-group" ng-show="serviceList">
-            <div ng-repeat="service in serviceList | filter: resourceRegexFilter('id', resourceRegex)" ng-show="service.enabled || showDisabled">
-                <a href="#/resources/service/{{ service.id }}" class="dont-break-out list-group-item"><span class="glyphicon glyphicon-menu-right pull-right"></span><p class="list-group-item-heading">{{ service.id }}</p></span></a>
-            </div>
-          </div>
-        </div>
+      <div class="col-md-12 row-relative">
+        <table class="table table-hover">
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Revision</th>
+              <th>Modified</th>
+              <th>Modified By</th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr ng-repeat="resource in credentialList | filter: resourceRegexFilter('name', resourceRegex)" ng-click="gotoResource(resource, typeFilter)" style="cursor: pointer" ng-show="showResource(resource) && typeFilter == 'credentials'">
+              <td class="dont-break-out">{{ resource.name }}</td>
+              <td>{{ resource.revision }}</td>
+              <td>{{ resource.modified_date | date:'medium':'GMT' }}</td>
+              <td>{{ resource.modified_by }}</td>
+              <td><span class="glyphicon glyphicon-menu-right"></span></td>
+            </tr>
+            <tr ng-repeat="resource in blindCredentialList | filter: resourceRegexFilter('name', resourceRegex)" ng-click="gotoResource(resource, typeFilter)" style="cursor: pointer" ng-show="showResource(resource) && typeFilter == 'blind_credentials'">
+              <td class="dont-break-out">{{ resource.name }}</td>
+              <td>{{ resource.revision }}</td>
+              <td>{{ resource.modified_date | date:'medium':'GMT' }}</td>
+              <td>{{ resource.modified_by }}</td>
+              <td><span class="glyphicon glyphicon-menu-right"></span></td>
+            </tr>
+            <tr ng-repeat="resource in serviceList | filter: resourceRegexFilter('id', resourceRegex)" ng-click="gotoResource(resource, typeFilter)" style="cursor: pointer" ng-show="showResource(resource) && typeFilter == 'services'">
+              <td class="dont-break-out">{{ resource.id }}</td>
+              <td>{{ resource.revision }}</td>
+              <td>{{ resource.modified_date | date:'medium':'GMT' }}</td>
+              <td>{{ resource.modified_by }}</td>
+              <td><span class="glyphicon glyphicon-menu-right"></span></td>
+            </tr>
+          </tbody>
+        </table>
       </div>
     </div>
   </div>
-  <div class="col-md-8 row-overflow">
+  <div class="col-md-7 row-overflow">
     <div ui-view="details"><div class="row"><div class="no-details-text"><h3>No resource selected.</h3></div></div></div>
     <div ui-view="docs"></div>
   </div>

--- a/confidant/public/modules/resources/views/service-details.html
+++ b/confidant/public/modules/resources/views/service-details.html
@@ -11,7 +11,7 @@
       <ul>
         <li>Credentials:</li>
         <ul>
-          <li ng-repeat="credentialId in conflicts.credentials"><a class="color-text-snow" href="#/resources/credential/{{ credentialId }}">{{ getCredentialByID(credentialId).name }}</a></li>
+          <li ng-repeat="credentialId in conflicts.credentials"><a class="color-text-snow" href="#/resources/credentials/{{ credentialId }}">{{ getCredentialByID(credentialId).name }}</a></li>
         </ul>
       </ul>
     </li>
@@ -20,7 +20,7 @@
       <ul>
         <li>Blind Credentials:</li>
         <ul>
-          <li ng-repeat="credentialId in conflicts.blind_credentials"><a class="color-text-snow" href="#/resources/blind_credential/{{ credentialId }}">{{ getBlindCredentialByID(credentialId).name }}</a></li>
+          <li ng-repeat="credentialId in conflicts.blind_credentials"><a class="color-text-snow" href="#/resources/blind_credentials/{{ credentialId }}">{{ getBlindCredentialByID(credentialId).name }}</a></li>
         </ul>
       </ul>
     </li>
@@ -50,7 +50,7 @@
       <div ng-repeat="credential in service.credentials | filter:filterCredentials" class="row">
         <div class="col-md-8">
           <span editable-select="credential.id" e-ng-selected="credential.id == c.id" e-name="{{ credential.id }}SelectMenu" e-ng-options="c.id as c.name for c in $parent.credentialList | filter:filterCredentialOptions">
-            <a href="#/resources/credential/{{ credential.id }}">{{ credential.name }} <span ng-hide="credential.enabled">(disabled)</span></a>
+            <a href="#/resources/credentials/{{ credential.id }}">{{ credential.name }} <span ng-hide="credential.enabled">(disabled)</span></a>
           </span>
           <span ng-hide="editableForm.$visible">(Revision: {{ credential.revision }})</span>
         </div>
@@ -71,7 +71,7 @@
       <div ng-repeat="blind_credential in service.blind_credentials | filter:filterCredentials" class="row">
         <div class="col-md-8">
           <span editable-select="blind_credential.id" e-ng-selected="blind_credential.id == c.id" e-name="{{ blind_credential.id }}SelectMenu" e-ng-options="c.id as c.name for c in $parent.blindCredentialList | filter:filterBlindCredentialOptions">
-            <a href="#/resources/blind_credential/{{ blind_credential.id }}">{{ blind_credential.name }} <span ng-hide="blind_credential.enabled">(disabled)</span></a>
+            <a href="#/resources/blind_credentials/{{ blind_credential.id }}">{{ blind_credential.name }} <span ng-hide="blind_credential.enabled">(disabled)</span></a>
             <!--{{ blind_credential.name }} <span ng-hide="blind_credential.enabled">(disabled)-->
           </span>
           <span ng-hide="editableForm.$visible">(Revision: {{ blind_credential.revision }})</span>
@@ -97,7 +97,7 @@
   </div>
   <div class="form-group" ng-hide="newService || missingService">
     <label for="serviceRevision">Service Revision</label>
-    <span id="serviceRevision">{{ service.revision }}</span>
+    <span id="serviceRevision">{{ service.revision }} (<a href="#/history/services/{{ service.id }}-{{ service.revision }}">view history</a>)</span>
   </div>
   <div class="form-group" ng-hide="newService || missingService || !showGrants">
     <label for="serviceGrants">Service Grants</label>
@@ -108,9 +108,9 @@
     </ul>
   </div>
   <div class="buttons">
-    <button type="button" class="btn btn-default" ng-click="editableForm.$show()" ng-show="!editableForm.$visible">Edit</button>
+    <button type="button" class="btn btn-default call-to-action" ng-click="editableForm.$show()" ng-show="!editableForm.$visible">Edit</button>
     <span ng-show="editableForm.$visible">
-      <button type="submit" class="btn" ng-disabled="editableForm.$waiting">Save</button>
+      <button type="submit" class="btn call-to-action" ng-disabled="editableForm.$waiting">Save</button>
       <button type="button" class="btn btn-alternate" ng-disabled="editableForm.$waiting" ng-click="editableForm.$cancel()">Cancel</button>
     </span>
   </div>

--- a/confidant/public/modules/routes/resources.js
+++ b/confidant/public/modules/routes/resources.js
@@ -50,7 +50,7 @@
         })
 
         .state('resources.credential-details', {
-            url: '/credential/:credentialId',
+            url: '/credentials/:credentialId',
             views: {
                 'details': {
                     controller: 'resources.CredentialDetailsCtrl',
@@ -67,7 +67,7 @@
         })
 
         .state('resources.blind-credential-details', {
-            url: '/blind_credential/:blindCredentialId',
+            url: '/blind_credentials/:blindCredentialId',
             views: {
                 'details': {
                     controller: 'resources.BlindCredentialDetailsCtrl',
@@ -84,7 +84,7 @@
         })
 
         .state('resources.service-details', {
-            url: '/service/:serviceId',
+            url: '/services/:serviceId',
             views: {
                 'details': {
                     controller: 'resources.ServiceDetailsCtrl',

--- a/confidant/public/styles/main.css
+++ b/confidant/public/styles/main.css
@@ -41,13 +41,13 @@ body {
 .row-overflow-resources {
   position: relative;
   overflow-y: auto;
-  height: calc(100% - 70px);
+  height: calc(100% - 120px);
 }
 
 .row-overflow-history-resources {
   position: relative;
   overflow-y: auto;
-  height: calc(100% - 70px);
+  height: calc(100% - 90px);
 }
 
 .row-overflow {
@@ -142,8 +142,18 @@ body {
   content: "+ ";
 }
 
-.history-active {
+.active {
   color: #337ab7;
+}
+
+.call-to-action {
+  background-color: rgb(51, 102, 204);
+  color: #FFF;
+}
+
+.call-to-action:hover {
+  background-color: #337ab7;
+  color: #FFF;
 }
 
 /*


### PR DESCRIPTION
This change refactors the resources view to be consistent with the history view for resources. Rather than showing all resources of one type in the same list, there's a toggle view between credentials, blind credentials, and services. I also pulled the create toggle into the same row as the toggles, and away from the filter, which was confusing for folks in the past.

This change also adds links to a resource's history from the details view. It also styles the action callout buttons (create, edit, save, revert) to make them more apparent.