### PR TITLE
Refactor diff view for services to match credentials diff

### DIFF
--- a/confidant/models/credential.py
+++ b/confidant/models/credential.py
@@ -93,6 +93,14 @@ class Credential(Model):
                 'added': new.documentation,
                 'removed': old.documentation
             }
+        diff['modified_by'] = {
+            'added': new.modified_by,
+            'removed': old.modified_by,
+        }
+        diff['modified_date'] = {
+            'added': new.modified_date,
+            'removed': old.modified_date,
+        }
         return diff
 
     def _diff_dict(self, old, new):

--- a/confidant/models/service.py
+++ b/confidant/models/service.py
@@ -54,3 +54,53 @@ class Service(Model):
         if self.account != other_service.account:
             return False
         return True
+
+    def diff(self, other_service):
+        if self.revision == other_service.revision:
+            return {}
+        elif self.revision > other_service.revision:
+            old = other_service
+            new = self
+        else:
+            old = self
+            new = other_service
+        diff = {}
+        if old.enabled != new.enabled:
+            diff['enabled'] = {'added': new.enabled, 'removed': old.enabled}
+        if old.credentials != new.credentials:
+            diff['credentials'] = self._diff_list(
+                old.credentials,
+                new.credentials,
+            )
+        if old.blind_credentials != new.blind_credentials:
+            diff['blind_credentials'] = self._diff_list(
+                old.blind_credentials,
+                new.blind_credentials,
+            )
+        if old.account != new.account:
+            diff['account'] = {'added': new.account, 'removed': old.account}
+        diff['modified_by'] = {
+            'added': new.modified_by,
+            'removed': old.modified_by,
+        }
+        diff['modified_date'] = {
+            'added': new.modified_date,
+            'removed': old.modified_date,
+        }
+        return diff
+
+    def _diff_list(self, old, new):
+        diff = {}
+        removed = []
+        added = []
+        for key in old:
+            if key not in new:
+                removed.append(key)
+        for key in new:
+            if key not in old:
+                added.append(key)
+        if removed:
+            diff['removed'] = sorted(removed)
+        if added:
+            diff['added'] = sorted(added)
+        return diff

--- a/confidant/public/modules/common/constants.js
+++ b/confidant/public/modules/common/constants.js
@@ -14,6 +14,7 @@
         DATAKEY: 'v1/datakey',
         SERVICE: 'v1/services/:id',
         SERVICE_REVISION: 'v1/services/:id/:revision',
+        SERVICE_DIFF: 'v1/services/:id/:old_revision/:new_revision',
         SERVICES: 'v1/services',
         GRANTS: 'v1/grants/:id',
         ARCHIVE_SERVICES: 'v1/archive/services',

--- a/confidant/public/modules/history/controllers/ServiceHistoryCtrl.js
+++ b/confidant/public/modules/history/controllers/ServiceHistoryCtrl.js
@@ -18,11 +18,17 @@
         '$log',
         '$location',
         'services.service',
+        'services.serviceDiff',
         'services.archiveServiceRevisions',
         'history.ResourceArchiveService',
-        function ($scope, $stateParams, $filter, $q, $log, $location, Service, ServiceArchiveRevisions, ResourceArchiveService) {
+        function ($scope, $stateParams, $filter, $q, $log, $location, Service, ServiceDiff, ServiceArchiveRevisions, ResourceArchiveService) {
             $scope.$log = $log;
             $scope.revisions = [];
+            $scope.getError = '';
+            $scope.saveError = '';
+            $scope.noDiff = false;
+            // TODO: set this from the return value
+            $scope.hasDiff = true;
 
             var idArr = $stateParams.serviceId.split('-');
             $scope.serviceRevision = parseInt(idArr.pop(), 10);
@@ -30,15 +36,25 @@
             ServiceArchiveRevisions.get({'id': $scope.serviceId}).$promise.then(function(revisions) {
                 $scope.revisions = $filter('orderBy')(revisions.revisions, 'revision', true);
                 $scope.currentRevision = parseInt($scope.revisions[0].revision, 10);
+                $scope.currentService = $scope.revisions[0];
+                $scope.isOnlyRevision = false;
                 if ($scope.currentRevision === 1) {
                     $scope.isOnlyRevision = true;
-                    $scope.diffRevision = $scope.currentRevision;
                 } else {
                     if ($scope.serviceRevision === $scope.currentRevision) {
                         $scope.diffRevision = $scope.currentRevision - 1;
+                        $location.path('/history/services/' + $scope.serviceId + '-' + $scope.diffRevision);
                     } else {
                         $scope.diffRevision = $scope.serviceRevision;
                     }
+                    ServiceDiff.get({'id': $scope.serviceId, 'old_revision': $scope.diffRevision, 'new_revision': $scope.currentRevision}).$promise.then(function(diff) {
+                        $scope.diff = diff;
+                        if (angular.equals({}, diff)) {
+                            $scope.noDiff = true;
+                        }
+                    }, function(res) {
+                        $scope.getError = res.data.error;
+                    });
                 }
                 if ($scope.currentRevision === $scope.serviceRevision) {
                     $scope.isCurrentRevision = true;
@@ -69,6 +85,26 @@
                     return cred.id.indexOf(credId) === 0;
                 }), 'name');
                 return name;
+            };
+
+            $scope.getResourceValue = function(key, value) {
+                if (key === 'credentials') {
+                    return $scope.getCredentialName(value);
+                } else if (key === 'blind_credentials') {
+                    return $scope.getBlindCredentialName(value);
+                } else {
+                    return value;
+                }
+            };
+
+            $scope.shouldDisplayList = function(value) {
+                if (typeof value === 'string') {
+                    return false;
+                } else if (typeof value === 'boolean') {
+                    return false;
+                } else {
+                    return true;
+                }
             };
 
             $scope.revertToDiffRevision = function() {

--- a/confidant/public/modules/history/views/credential-history.html
+++ b/confidant/public/modules/history/views/credential-history.html
@@ -60,7 +60,7 @@
         <ul class="list-unstyled" ng-show="shouldDisplayList(diffValue.removed)">
           <li class="diff-removed-item" ng-repeat="removed in diffValue.removed track by $index">{{ removed }}</li>
         </ul>
-        <p ng-hide="shouldDisplayList(diffValue.removed)">{{ diffValue.removed }}</p>
+        <p class="diff-removed-item" ng-hide="shouldDisplayList(diffValue.removed)">{{ diffValue.removed }}</p>
         </div>
       </div>
       <div class="col-md-6 diff-added">

--- a/confidant/public/modules/history/views/service-history.html
+++ b/confidant/public/modules/history/views/service-history.html
@@ -28,65 +28,53 @@
   <p>Please ensure credential pair keys are unique for the mapped services, then try again.</p>
 </div>
 </div>
-<div class="well">
-  <h3 class="has-margin-bottom-lg">Difference between revisions of {{ serviceId }}</h3>
+<div class="alert alert-warning" ng-show="getError">
+<p>{{ getError }}</p>
+</div>
+<div class="well" ng-show="isOnlyRevision">
+  <h3 class="has-margin-bottom-lg">Only revision of {{ currentService.name }}</h3>
+  <p ng-show="isOnlyRevision">This is the only revision of this service. You'll need to <a href="#/resources/services/{{ serviceId }}">edit the service</a> to make any changes.</p>
+</div>
+<div class="well" ng-hide="isOnlyRevision || !hasDiff">
+  <h3 class="has-margin-bottom-lg">Difference between revisions of {{ currentService.name }}</h3>
   <div class="row">
     <a ng-show="serviceRevision > 1" style="float: left" class="has-margin-bottom-lg" href="#/history/services/{{ serviceId }}-{{ serviceRevision - 1 }}"><span class="glyphicon glyphicon-menu-left"></span> previous revision</a>
-    <a ng-show="serviceRevision < currentRevision" style="float: right" class="has-margin-bottom-lg" href="#/history/services/{{ serviceId }}-{{ serviceRevision + 1 }}">next revision <span class="glyphicon glyphicon-menu-right"></span></a>
+    <a ng-show="serviceRevision < currentRevision - 1" style="float: right" class="has-margin-bottom-lg" href="#/history/services/{{ serviceId }}-{{ serviceRevision + 1 }}">next revision <span class="glyphicon glyphicon-menu-right"></span></a>
   </div>
-  <div class="row">
-    <div class="col-md-6">
-      <div ng-hide="isOnlyRevision">
-        <h5>Revision {{ diffRevision }}</h5>
-        <h6>Enabled</h6>
-        <div class="well well-sm">
-          <p>{{ getServiceByRevision(diffRevision).enabled }}</p>
-        </div>
-        <h6>Credentials</h6>
-        <div class="well">
-          <ul class="list-unstyled" style="overflow: scroll">
-            <li ng-repeat="credential in getServiceByRevision(diffRevision).credentials">{{ getCredentialName(credential) }}</li>
-          </ul>
-        </div>
-        <h6>Blind Credentials</h6>
-        <div class="well">
-          <ul class="list-unstyled" style="overflow: scroll">
-            <li ng-repeat="blind_credential in getServiceByRevision(diffRevision).blind_credentials">{{ getBlindCredentialName(blind_credential) }}</li>
-          </ul>
-        </div>
-      </div>
-      <div ng-show="isOnlyRevision">
-        <h5>No other revision.</h5>
-      </div>
-    </div>
-    <div class="col-md-6">
-      <h5>Current revision</h5>
-      <h6>Enabled</h6>
-      <div class="well well-sm">
-        <p>{{ getServiceByRevision(currentRevision).enabled }}</p>
-      </div>
-      <h6>Credentials</h6>
-      <div class="well">
-        <ul class="list-unstyled" style="overflow: scroll">
-          <li ng-repeat="credential in getServiceByRevision(currentRevision).credentials">{{ getCredentialName(credential) }}</li>
-        </ul>
-      </div>
-      <h6>Blind Credentials</h6>
-      <div class="well">
-        <ul class="list-unstyled" style="overflow: scroll">
-          <li ng-repeat="blind_credential in getServiceByRevision(currentRevision).blind_credentials">{{ getBlindCredentialName(blind_credential) }}</li>
-        </ul>
-      </div>
-    </div>
+  <div ng-show="noDiff">
+    <p>No difference between revisions {{ diffRevision }} and {{ currentRevision }} for {{ currentService.name }}</p>
   </div>
-  <div ng-show="isCurrentRevision">
-    <p ng-show="isOnlyRevision">This is the only revision of this service. You'll need to <a href="#/resources/services/{{ serviceId }}">edit the service</a> to make any changes.</p>
-    <div ng-hide="isOnlyRevision">
-      <p class="has-margin-bottom-lg">This is the current revision of this service. The above diff is between the current revision and the previous revision.</p>
-      <button class="btn call-to-action" ng-click="revertToDiffRevision()">Revert to revision {{ diffRevision }}</button>
+  <div ng-hide="noDiff">
+  <div class="container-fluid">
+    <div class="row">
+      <div class="col-md-6 h3">Revision {{ diffRevision }}</div>
+      <div class="col-md-6 h3">Current revision</div>
+    </div>
+    <div class="has-margin-bottom-lg row" ng-repeat="(diffKey, diffValue) in diff">
+      <div class="has-margin-bottom-lg">
+        <div class="col-md-6 h4">{{ diffKey }}</div>
+        <div class="col-md-6 h4">{{ diffKey }}</div>
+      </div>
+      <div class="col-md-6 diff-removed">
+        <div>
+        <ul class="list-unstyled" ng-show="shouldDisplayList(diffValue.removed)">
+          <li class="diff-removed-item" ng-repeat="removed in diffValue.removed track by $index">{{ getResourceValue(diffKey, removed) }}</li>
+        </ul>
+        <p class="diff-removed-item" ng-hide="shouldDisplayList(diffValue.removed)">{{ diffValue.removed }}</p>
+        </div>
+      </div>
+      <div class="col-md-6 diff-added">
+        <div>
+        <ul class="list-unstyled" ng-show="shouldDisplayList(diffValue.added)">
+          <li class="diff-added-item" ng-repeat="added in diffValue.added track by $index">{{ getResourceValue(diffKey, added) }}</li>
+        </ul>
+        <p class="diff-added-item" ng-hide="shouldDisplayList(diffValue.added)">{{ diffValue.added }}</p>
+        </div>
+      </div>
     </div>
   </div>
   <div ng-hide="isCurrentRevision">
     <button class="btn call-to-action" ng-click="revertToDiffRevision()">Revert to revision {{ diffRevision }}</button>
   </div>
+  <div>
 </div>

--- a/confidant/public/modules/resources/services/confidantservices.js
+++ b/confidant/public/modules/resources/services/confidantservices.js
@@ -21,6 +21,10 @@
         });
     }])
 
+    .factory('services.serviceDiff', ['$resource', 'CONFIDANT_URLS', function($resource, CONFIDANT_URLS) {
+        return $resource(CONFIDANT_URLS.SERVICE_DIFF, {id: '@id', old_revision: '@old_revision', new_revision: '@new_revision'});
+    }])
+
     .factory('services.grants', ['$resource', 'CONFIDANT_URLS', function($resource, CONFIDANT_URLS) {
         return $resource(CONFIDANT_URLS.GRANTS, {id: '@id'}, {
             update: {method: 'PUT', isArray: false}

--- a/tests/unit/confidant/models/credential_test.py
+++ b/tests/unit/confidant/models/credential_test.py
@@ -1,5 +1,6 @@
 import unittest
 import mock
+from datetime import datetime
 
 from confidant.models.credential import Credential
 
@@ -49,12 +50,17 @@ class CredentialTest(unittest.TestCase):
         {},
     )
     def test_diff(self):
+        modified_by = 'test@example.com'
+        modified_date_old = datetime.now
+        modified_date_new = datetime.now
         old = Credential(
             name='test',
             revision=1,
             enabled=True,
             documentation='old',
             metadata={'hello': 'world'},
+            modified_by=modified_by,
+            modified_date=modified_date_old,
         )
         new = Credential(
             name='test2',
@@ -62,6 +68,8 @@ class CredentialTest(unittest.TestCase):
             enabled=True,
             documentation='',
             metadata={'foo': 'bar'},
+            modified_by=modified_by,
+            modified_date=modified_date_new,
         )
         # TODO: figure out how to test decrypted_credential_pairs. Mocking
         # it is turning out to be difficult.
@@ -77,6 +85,14 @@ class CredentialTest(unittest.TestCase):
             'documentation': {
                 'removed': 'old',
                 'added': '',
+            },
+            'modified_by': {
+                'removed': modified_by,
+                'added': modified_by,
+            },
+            'modified_date': {
+                'removed': modified_date_old,
+                'added': modified_date_new,
             },
         }
         self.assertEquals(old.diff(new), expectedDiff)


### PR DESCRIPTION
For consistency, this change refactors the controller and view for service diff to match how credentials is handled. This also adds a diff endpoint for services, with its own ACL.

Also, the diff views didn't show who edited the revisions, or when, so I've added modified_by and modified_date to both diffs.