### PR TITLE
Fix mapping credentials

### DIFF
--- a/confidant/routes/services.py
+++ b/confidant/routes/services.py
@@ -221,33 +221,32 @@ def map_service_credentials(id):
         _service = None
 
     data = request.get_json()
-    if data.get('credentials') or data.get('blind_credentials'):
-        credentials = data.get('credentials', [])
-        blind_credentials = data.get('blind_credentials', [])
-        credentials = credentials + blind_credentials
-        if not acl_module_check(resource_type='service',
-                                action='update',
-                                resource_id=id,
-                                kwargs={
-                                    'credential_ids': credentials,
-                                }):
-            msg = "{} does not have access to map service credential {}".format(
-                authnz.get_logged_in_user(),
-                id
-            )
-            error_msg = {'error': msg, 'reference': id}
-            return jsonify(error_msg), 403
-
-        conflicts = credentialmanager.pair_key_conflicts_for_credentials(
-            credentials,
-            blind_credentials,
+    credentials = data.get('credentials', [])
+    blind_credentials = data.get('blind_credentials', [])
+    credentials = credentials + blind_credentials
+    if not acl_module_check(resource_type='service',
+                            action='update',
+                            resource_id=id,
+                            kwargs={
+                                'credential_ids': credentials,
+                            }):
+        msg = "{} does not have access to map service credential {}".format(
+            authnz.get_logged_in_user(),
+            id
         )
-        if conflicts:
-            ret = {
-                'error': 'Conflicting key pairs in mapped service.',
-                'conflicts': conflicts
-            }
-            return jsonify(ret), 400
+        error_msg = {'error': msg, 'reference': id}
+        return jsonify(error_msg), 403
+
+    conflicts = credentialmanager.pair_key_conflicts_for_credentials(
+        credentials,
+        blind_credentials,
+    )
+    if conflicts:
+        ret = {
+            'error': 'Conflicting key pairs in mapped service.',
+            'conflicts': conflicts
+        }
+        return jsonify(ret), 400
 
     accounts = list(app.config['SCOPED_AUTH_KEYS'].values())
     if data.get('account') and data['account'] not in accounts:


### PR DESCRIPTION
The original `if` statement to check if there are credentials will never execute if a user deletes all credentials from a service.  `data.get('credentials')` will always return false when the service returns an empty list.  I think the original intention was to check that the key exists.

I've removed the if statement all together since `data.get('credentials', [])` will default to an empty list to check anyway.