### PR TITLE
Remove webargs and FlaskParser for now

### DIFF
--- a/confidant/schema/auto_build_schema.py
+++ b/confidant/schema/auto_build_schema.py
@@ -1,6 +1,4 @@
 from marshmallow import post_load, Schema
-from webargs import core
-from webargs.flaskparser import FlaskParser as FlaskParser_
 
 
 class StrictSchema(Schema):
@@ -59,30 +57,3 @@ class AutobuildSchema(StrictSchema):
             raise NotImplementedError('Subclass did not set "_class_to_load"')
 
         return self._class_to_load(**data)
-
-
-class FlaskParser(FlaskParser_):
-    """
-    This subclass of the webargs FlaskParser[1] propagates the marshmallow
-    ValidationError so we can format it nicely.
-
-    [1] https://github.com/sloria/webargs/blob/dev/webargs/flaskparser.py
-    """
-
-    def handle_error(self, error):
-        """
-        :type error: marshmallow.ValidationError
-        """
-        raise error
-
-    def parse_json(self, req, name, field):
-        """Pull a json value from the request."""
-
-        json_data = req.get_json(force=True, silent=True)
-        if json_data:
-            return core.get_value(json_data, name, field)
-        else:
-            return core.missing
-
-
-parser = FlaskParser()

--- a/requirements.in
+++ b/requirements.in
@@ -161,17 +161,6 @@ statsd==3.2.1
 # Use: kmsauth support library
 kmsauth==0.5.0
 
-# License: MIT
-# Schemas for handling complex datatypes
--e git+https://github.com/lyft/marshmallow@2.15.1#egg=marshmallow
-
-# License: MIT
-# A friendly library for parsing HTTP request arguments, with built-in support
-# for popular web frameworks, including Flask, Django, Bottle, Tornado,
-# Pyramid, webapp2, Falcon, and aiohttp. http://webargs.readthedocs.io/
-# https://github.com/sloria/webargs
-webargs==1.8.1
-
 # License: Apache2
 # Upstream url: https://pypi.python.org/pypi/toasted-marshmallow
 # Use: input/output validation and json serialization

--- a/requirements.txt
+++ b/requirements.txt
@@ -62,7 +62,6 @@ statsd==3.2.1
 toastedmarshmallow==2.15.2.post1
 typing==3.7.4.1           # via flake8
 urllib3==1.25.3           # via botocore, requests
-webargs==1.8.1
 werkzeug==0.15.6          # via flask
 xmlsec==1.3.3             # via python3-saml
 

--- a/requirements3.txt
+++ b/requirements3.txt
@@ -4,7 +4,6 @@
 #
 #    pip-compile --output-file=./requirements3.txt ./requirements.in
 #
--e git+https://github.com/lyft/marshmallow@2.15.1#egg=marshmallow
 asn1crypto==0.24.0        # via cryptography
 attrs==19.3.0             # via toastedmarshmallow
 authomatic==0.1.0.post1
@@ -59,6 +58,5 @@ six==1.12.0               # via cryptography, isodate, mock, pynamodb, pyopenssl
 statsd==3.2.1
 toastedmarshmallow==2.15.2.post1
 urllib3==1.25.3           # via botocore, requests
-webargs==1.8.1
 werkzeug==0.15.6          # via flask
 xmlsec==1.3.3             # via python3-saml


### PR DESCRIPTION
This change is in response to https://github.com/lyft/confidant/issues/241. It removes webargs and the `-e git` install of toastedmarshmallow fork to fix the build+dist in CI, so we can publish releases.