### PR TITLE
Check that credential keys are empty in if statement

### DIFF
--- a/confidant/public/modules/resources/controllers/CredentialDetailsCtrl.js
+++ b/confidant/public/modules/resources/controllers/CredentialDetailsCtrl.js
@@ -61,14 +61,14 @@
                 Credential.get({'id': $stateParams.credentialId}).$promise.then(function(credential) {
                     var _credentialPairs = [],
                         _metadata = [];
-                    if (credential.credential_pairs) {
+                    if (Object.entries(credential.credential_pairs).length) {
                         angular.forEach(credential.credential_pairs, function(value, key) {
                             this.push({'key': key, 'value': value});
                         }, _credentialPairs);
                         credential.credentialPairs = _credentialPairs;
                         $scope.hasView = true;
                     }
-                    if (credential.credential_keys) {
+                    if (credential.credential_keys.length) {
                         $scope.hasMetadata = true;
                     }
                     angular.forEach(credential.metadata, function(value, key) {

--- a/confidant/public/modules/resources/controllers/CredentialDetailsCtrl.js
+++ b/confidant/public/modules/resources/controllers/CredentialDetailsCtrl.js
@@ -61,7 +61,7 @@
                 Credential.get({'id': $stateParams.credentialId}).$promise.then(function(credential) {
                     var _credentialPairs = [],
                         _metadata = [];
-                    if (angular.equals({}, credential.credential_pairs)) {
+                    if (!angular.equals({}, credential.credential_pairs)) {
                         angular.forEach(credential.credential_pairs, function(value, key) {
                             this.push({'key': key, 'value': value});
                         }, _credentialPairs);

--- a/confidant/public/modules/resources/controllers/CredentialDetailsCtrl.js
+++ b/confidant/public/modules/resources/controllers/CredentialDetailsCtrl.js
@@ -61,7 +61,7 @@
                 Credential.get({'id': $stateParams.credentialId}).$promise.then(function(credential) {
                     var _credentialPairs = [],
                         _metadata = [];
-                    if (Object.entries(credential.credential_pairs).length) {
+                    if (angular.equals({}, credential.credential_pairs)) {
                         angular.forEach(credential.credential_pairs, function(value, key) {
                             this.push({'key': key, 'value': value});
                         }, _credentialPairs);


### PR DESCRIPTION
With the recent marshmallow changes, we will always return `credential.credential_pairs`  even if there are no values.

In javascript, `if ({}) { ... }` and `if([]) {...}` will always evaluate to `true`.  This small hotfix will check that there are dictionary keys or length > 0 in an array instead.

The prior changes that affected this:

Setting the key only if the acl module check passes:
https://github.com/lyft/confidant/commit/7f18aedfbed3523aa0d4a4de3d8c93f83be7604e#diff-4f80e4527a99290e72983a3a8cde9808L101

The default value of the marshmallow response object:
https://github.com/lyft/confidant/commit/7f18aedfbed3523aa0d4a4de3d8c93f83be7604e#diff-e6fef3dba80952520b0fe3e8011f5b90R20