### PR TITLE
Switch to a blueprint/create_app pattern

### DIFF
--- a/confidant/app.py
+++ b/confidant/app.py
@@ -38,7 +38,7 @@ def create_app():
     app.debug = settings.DEBUG
 
     if settings.SSLIFY:
-        sslify = SSLify(app, skips=['healthcheck'])  # noqa
+        SSLify(app, skips=['healthcheck'])
 
     app.wsgi_app = guard.ContentSecurityPolicy(app.wsgi_app, CSP_POLICY)
 

--- a/confidant/app.py
+++ b/confidant/app.py
@@ -5,6 +5,14 @@ from flask import Flask
 from flask_sslify import SSLify
 
 from confidant import settings
+from confidant.routes import (
+    blind_credentials,
+    credentials,
+    identity,
+    saml,
+    services,
+    static_files,
+)
 
 
 if not settings.get('DEBUG'):
@@ -12,22 +20,33 @@ if not settings.get('DEBUG'):
     logging.getLogger('botocore').setLevel(logging.CRITICAL)
     logging.getLogger('pynamodb').setLevel(logging.WARNING)
 
-static_folder = settings.get('STATIC_FOLDER')
 
-app = Flask(__name__, static_folder=static_folder)
-app.config.from_object(settings)
-app.config.update(settings.encrypted_settings.get_all_secrets())
-app.debug = app.config['DEBUG']
+def create_app():
+    static_folder = settings.STATIC_FOLDER
 
-if app.config['SSLIFY']:
-    sslify = SSLify(app, skips=['healthcheck'])  # noqa
+    app = Flask(__name__, static_folder=static_folder)
+    app.config.from_object(settings)
+    app.config.update(settings.encrypted_settings.get_all_secrets())
+    app.debug = settings.DEBUG
 
-if app.config.get('REDIS_URL'):
-    import redis
-    from flask.ext.session import Session
-    app.config['SESSION_REDIS'] = redis.Redis.from_url(
-        app.config['REDIS_URL']
-    )
-    Session(app)
+    if settings.SSLIFY:
+        sslify = SSLify(app, skips=['healthcheck'])  # noqa
 
-app.secret_key = app.config['SESSION_SECRET']
+    if settings.REDIS_URL:
+        import redis
+        from flask.ext.session import Session
+        app.config['SESSION_REDIS'] = redis.Redis.from_url(
+            settings.REDIS_URL
+        )
+        Session(app)
+
+    app.secret_key = settings.SESSION_SECRET
+
+    app.register_blueprint(blind_credentials.blueprint)
+    app.register_blueprint(credentials.blueprint)
+    app.register_blueprint(identity.blueprint)
+    app.register_blueprint(saml.blueprint)
+    app.register_blueprint(services.blueprint)
+    app.register_blueprint(static_files.blueprint)
+
+    return app

--- a/confidant/encrypted_settings.py
+++ b/confidant/encrypted_settings.py
@@ -22,6 +22,7 @@ class EncryptedSettings(object):
         if name not in self.secret_names:
             self.secret_names.append(name)
             self.secret_defaults[name] = default
+        return self.get_secret(name)
 
     def registered(self, name):
         return name in self.secret_names

--- a/confidant/models/__init__.py
+++ b/confidant/models/__init__.py
@@ -1,5 +1,5 @@
-from confidant.app import app
+from confidant import settings
 from confidant.utils.dynamodb import create_dynamodb_tables
 
-if app.config['DYNAMODB_CREATE_TABLE']:
+if settings.DYNAMODB_CREATE_TABLE:
     create_dynamodb_tables()

--- a/confidant/models/blind_credential.py
+++ b/confidant/models/blind_credential.py
@@ -10,7 +10,7 @@ from pynamodb.attributes import (
 )
 from pynamodb.indexes import GlobalSecondaryIndex, AllProjection
 
-from confidant.app import app
+from confidant import settings
 from confidant.models.session_cls import DDBSession
 from confidant.models.connection_cls import DDBConnection
 from confidant.models.non_null_unicode_set_attribute import (
@@ -29,10 +29,10 @@ class DataTypeDateIndex(GlobalSecondaryIndex):
 
 class BlindCredential(Model):
     class Meta:
-        table_name = app.config.get('DYNAMODB_TABLE')
-        if app.config.get('DYNAMODB_URL'):
-            host = app.config.get('DYNAMODB_URL')
-        region = app.config.get('AWS_DEFAULT_REGION')
+        table_name = settings.DYNAMODB_TABLE
+        if settings.DYNAMODB_URL:
+            host = settings.DYNAMODB_URL
+        region = settings.AWS_DEFAULT_REGION
         connection_cls = DDBConnection
         session_cls = DDBSession
 

--- a/confidant/models/connection_cls.py
+++ b/confidant/models/connection_cls.py
@@ -1,10 +1,10 @@
 import pynamodb.connection
 
-from confidant.app import app
+from confidant import settings
 
 
 class DDBConnection(pynamodb.connection.Connection):
     def __init__(self, *args, **kwargs):
         super(DDBConnection, self).__init__(*args, **kwargs)
-        _timeout_secs = app.config['PYNAMO_REQUEST_TIMEOUT_SECONDS']
+        _timeout_secs = settings.PYNAMO_REQUEST_TIMEOUT_SECONDS
         self._request_timeout_seconds = _timeout_secs

--- a/confidant/models/credential.py
+++ b/confidant/models/credential.py
@@ -12,7 +12,7 @@ from pynamodb.attributes import (
 )
 from pynamodb.indexes import GlobalSecondaryIndex, AllProjection
 
-from confidant.app import app
+from confidant import settings
 from confidant.models.session_cls import DDBSession
 from confidant.models.connection_cls import DDBConnection
 from confidant.services import keymanager
@@ -30,10 +30,10 @@ class DataTypeDateIndex(GlobalSecondaryIndex):
 
 class Credential(Model):
     class Meta:
-        table_name = app.config.get('DYNAMODB_TABLE')
-        if app.config.get('DYNAMODB_URL'):
-            host = app.config.get('DYNAMODB_URL')
-        region = app.config.get('AWS_DEFAULT_REGION')
+        table_name = settings.DYNAMODB_TABLE
+        if settings.DYNAMODB_URL:
+            host = settings.DYNAMODB_URL
+        region = settings.AWS_DEFAULT_REGION
         connection_cls = DDBConnection
         session_cls = DDBSession
 

--- a/confidant/models/service.py
+++ b/confidant/models/service.py
@@ -9,7 +9,7 @@ from pynamodb.attributes import (
 )
 from pynamodb.indexes import GlobalSecondaryIndex, AllProjection
 
-from confidant.app import app
+from confidant import settings
 from confidant.models.session_cls import DDBSession
 from confidant.models.connection_cls import DDBConnection
 from confidant.models.non_null_unicode_set_attribute import (
@@ -28,10 +28,10 @@ class DataTypeDateIndex(GlobalSecondaryIndex):
 
 class Service(Model):
     class Meta:
-        table_name = app.config.get('DYNAMODB_TABLE')
-        if app.config.get('DYNAMODB_URL'):
-            host = app.config.get('DYNAMODB_URL')
-        region = app.config.get('AWS_DEFAULT_REGION')
+        table_name = settings.DYNAMODB_TABLE
+        if settings.DYNAMODB_URL:
+            host = settings.DYNAMODB_URL
+        region = settings.AWS_DEFAULT_REGION
         connection_cls = DDBConnection
         session_cls = DDBSession
 

--- a/confidant/models/session_cls.py
+++ b/confidant/models/session_cls.py
@@ -1,15 +1,15 @@
 from botocore.vendored.requests import Session as BotoRequestsSession
 from botocore.vendored.requests.adapters import HTTPAdapter as BotoHTTPAdapter
 
-from confidant.app import app
+from confidant import settings
 
 
 class DDBSession(BotoRequestsSession):
     def __init__(self):
         super(DDBSession, self).__init__()
         self.mount('https://', BotoHTTPAdapter(
-            pool_maxsize=app.config['PYNAMO_CONNECTION_POOL_SIZE']
+            pool_maxsize=settings.PYNAMO_CONNECTION_POOL_SIZE
         ))
         self.mount('http://', BotoHTTPAdapter(
-            pool_maxsize=app.config['PYNAMO_CONNECTION_POOL_SIZE']
+            pool_maxsize=settings.PYNAMO_CONNECTION_POOL_SIZE
         ))

--- a/confidant/routes/__init__.py
+++ b/confidant/routes/__init__.py
@@ -1,8 +1,0 @@
-from confidant.routes import (  # noqa:F401
-    blind_credentials,
-    credentials,
-    identity,
-    saml,
-    services,
-    static_files,
-)

--- a/confidant/routes/blind_credentials.py
+++ b/confidant/routes/blind_credentials.py
@@ -1,11 +1,10 @@
 import logging
 import uuid
 
-from flask import jsonify, request
+from flask import blueprints, jsonify, request
 from pynamodb.exceptions import DoesNotExist, PutError
 
 from confidant import authnz, settings
-from confidant.app import app
 from confidant.services import (
     credentialmanager,
     graphite,
@@ -19,11 +18,12 @@ from confidant.utils.dynamodb import (
 )
 from confidant.models.blind_credential import BlindCredential
 
+blueprint = blueprints.Blueprint('blind_credentials', __name__)
 
 acl_module_check = misc.load_module(settings.ACL_MODULE)
 
 
-@app.route('/v1/blind_credentials', methods=['GET'])
+@blueprint.route('/v1/blind_credentials', methods=['GET'])
 @authnz.require_auth
 def get_blind_credential_list():
     blind_credentials = []
@@ -40,7 +40,7 @@ def get_blind_credential_list():
     return jsonify({'blind_credentials': blind_credentials})
 
 
-@app.route('/v1/blind_credentials/<id>', methods=['GET'])
+@blueprint.route('/v1/blind_credentials/<id>', methods=['GET'])
 @authnz.require_auth
 def get_blind_credential(id):
     try:
@@ -70,7 +70,7 @@ def get_blind_credential(id):
     })
 
 
-@app.route('/v1/archive/blind_credentials/<id>', methods=['GET'])
+@blueprint.route('/v1/archive/blind_credentials/<id>', methods=['GET'])
 @authnz.require_auth
 def get_archive_blind_credential_revisions(id):
     try:
@@ -113,7 +113,7 @@ def get_archive_blind_credential_revisions(id):
     })
 
 
-@app.route('/v1/archive/blind_credentials', methods=['GET'])
+@blueprint.route('/v1/archive/blind_credentials', methods=['GET'])
 @authnz.require_auth
 def get_archive_blind_credential_list():
     limit = request.args.get(
@@ -158,7 +158,7 @@ def get_archive_blind_credential_list():
     return jsonify(credential_list)
 
 
-@app.route('/v1/blind_credentials', methods=['POST'])
+@blueprint.route('/v1/blind_credentials', methods=['POST'])
 @authnz.require_auth
 @authnz.require_csrf_token
 @maintenance.check_maintenance_mode
@@ -244,7 +244,7 @@ def create_blind_credential():
     })
 
 
-@app.route('/v1/blind_credentials/<id>/services', methods=['GET'])
+@blueprint.route('/v1/blind_credentials/<id>/services', methods=['GET'])
 @authnz.require_auth
 def get_blind_credential_dependencies(id):
     services = servicemanager.get_services_for_blind_credential(id)
@@ -254,7 +254,7 @@ def get_blind_credential_dependencies(id):
     })
 
 
-@app.route('/v1/blind_credentials/<id>', methods=['PUT'])
+@blueprint.route('/v1/blind_credentials/<id>', methods=['PUT'])
 @authnz.require_auth
 @authnz.require_csrf_token
 @maintenance.check_maintenance_mode
@@ -394,7 +394,7 @@ def update_blind_credential(id):
     })
 
 
-@app.route('/v1/blind_credentials/<id>/<to_revision>', methods=['PUT'])
+@blueprint.route('/v1/blind_credentials/<id>/<to_revision>', methods=['PUT'])
 @authnz.require_auth
 @authnz.require_csrf_token
 @maintenance.check_maintenance_mode

--- a/confidant/routes/identity.py
+++ b/confidant/routes/identity.py
@@ -1,10 +1,11 @@
-from flask import jsonify
+from flask import blueprints, jsonify
 
 from confidant import authnz, settings
-from confidant.app import app
+
+blueprint = blueprints.Blueprint('identity', __name__)
 
 
-@app.route('/v1/login', methods=['GET', 'POST'])
+@blueprint.route('/v1/login', methods=['GET', 'POST'])
 def login():
     '''
     Send user through login flow.
@@ -12,7 +13,7 @@ def login():
     return authnz.log_in()
 
 
-@app.route('/v1/user/email', methods=['GET', 'POST'])
+@blueprint.route('/v1/user/email', methods=['GET', 'POST'])
 @authnz.require_auth
 def get_user_info():
     '''
@@ -25,7 +26,7 @@ def get_user_info():
     return response
 
 
-@app.route('/v1/client_config', methods=['GET'])
+@blueprint.route('/v1/client_config', methods=['GET'])
 @authnz.require_auth
 def get_client_config():
     '''

--- a/confidant/routes/saml.py
+++ b/confidant/routes/saml.py
@@ -1,13 +1,14 @@
 import logging
 
 import flask
-from flask import jsonify, request, session
+from flask import blueprints, jsonify, request, session
 
-from confidant import authnz
-from confidant.app import app
+from confidant import authnz, settings
+
+blueprint = blueprints.Blueprint('saml', __name__)
 
 
-@app.route('/v1/saml/metadata', methods=['GET'])
+@blueprint.route('/v1/saml/metadata', methods=['GET'])
 def get_saml_metadata():
     """
     Generate SAML metadata XML describing the service endpoints.
@@ -15,7 +16,7 @@ def get_saml_metadata():
     return authnz.user_mod.generate_metadata()
 
 
-@app.route('/v1/saml/consume', methods=['POST'])
+@blueprint.route('/v1/saml/consume', methods=['POST'])
 def consume_saml_assertion():
     """
     The SAML attribute consumer service receives POST callbacks from the IdP.
@@ -23,7 +24,7 @@ def consume_saml_assertion():
     return authnz.user_mod.consume_saml_assertion()
 
 
-@app.route('/v1/saml/login', methods=['GET'])
+@blueprint.route('/v1/saml/login', methods=['GET'])
 def generate_saml_login_redirect():
     """
     Redirect to the SAML login page. You don't normally need to hit this
@@ -33,7 +34,7 @@ def generate_saml_login_redirect():
         authnz.user_mod.login_redirect_url(return_to='/v1/saml/debug'))
 
 
-@app.route('/v1/saml/logout', methods=['GET'])
+@blueprint.route('/v1/saml/logout', methods=['GET'])
 def saml_logout():
     """
     This dual purpose route both initiates SingleLogOut redirects to the IdP
@@ -49,11 +50,11 @@ def saml_logout():
         return authnz.user_mod.log_out()
 
 
-@app.route('/v1/saml/debug', methods=['GET'])
+@blueprint.route('/v1/saml/debug', methods=['GET'])
 def dump_session_info():
     """Debug endpoint to show SAML attributes."""
 
-    if not app.debug:
+    if not settings.SAML_DEBUG:
         msg = "Cannot display /debug, not in DEBUG mode."
         logging.info(msg)
         return flask.make_response(msg, 403)

--- a/confidant/routes/static_files.py
+++ b/confidant/routes/static_files.py
@@ -1,79 +1,80 @@
 import os
 import logging
 
-from flask import send_from_directory
+from flask import blueprints, current_app, send_from_directory
 from werkzeug.exceptions import NotFound
 
-from confidant import authnz
-from confidant.app import app
+from confidant import authnz, settings
+
+blueprint = blueprints.Blueprint('static_files', __name__)
 
 
-@app.route('/')
+@blueprint.route('/')
 @authnz.redirect_to_logout_if_no_auth
 def index():
-    return app.send_static_file('index.html')
+    return current_app.send_static_file('index.html')
 
 
-@app.route('/loggedout')
+@blueprint.route('/loggedout')
 @authnz.require_logout_for_goodbye
 def goodbye():
-    return app.send_static_file('goodbye.html')
+    return current_app.send_static_file('goodbye.html')
 
 
-@app.route('/healthcheck')
+@blueprint.route('/healthcheck')
 def healthcheck():
     return '', 200
 
 
-@app.route('/favicon.ico')
+@blueprint.route('/favicon.ico')
 def favicon():
-    return app.send_static_file('favicon.ico')
+    return current_app.send_static_file('favicon.ico')
 
 
-@app.route('/404.html')
+@blueprint.route('/404.html')
 def not_found():
-    return app.send_static_file('404.html')
+    return current_app.send_static_file('404.html')
 
 
-@app.route('/robots.txt')
+@blueprint.route('/robots.txt')
 def robots():
-    return app.send_static_file('robots.txt')
+    return current_app.send_static_file('robots.txt')
 
 
-@app.route('/components/<path:path>')
-@app.route('/bower_components/<path:path>')
+@blueprint.route('/components/<path:path>')
+@blueprint.route('/bower_components/<path:path>')
 def components(path):
-    return app.send_static_file(os.path.join('components', path))
+    return current_app.send_static_file(os.path.join('components', path))
 
 
-@app.route('/modules/<path:path>')
+@blueprint.route('/modules/<path:path>')
 def modules(path):
-    return app.send_static_file(os.path.join('modules', path))
+    return current_app.send_static_file(os.path.join('modules', path))
 
 
-@app.route('/styles/<path:path>')
+@blueprint.route('/styles/<path:path>')
 def static_proxy(path):
-    return app.send_static_file(os.path.join('styles', path))
+    return current_app.send_static_file(os.path.join('styles', path))
 
 
-@app.route('/scripts/<path:path>')
+@blueprint.route('/scripts/<path:path>')
 def scripts(path):
-    return app.send_static_file(os.path.join('scripts', path))
+    return current_app.send_static_file(os.path.join('scripts', path))
 
 
-@app.route('/fonts/<path:path>')
+@blueprint.route('/fonts/<path:path>')
 def fonts(path):
-    return app.send_static_file(os.path.join('fonts', path))
+    return current_app.send_static_file(os.path.join('fonts', path))
 
 
-@app.route('/custom/modules/<path:path>')
+@blueprint.route('/custom/modules/<path:path>')
 @authnz.require_auth
 def custom_modules(path):
-    if not app.config['CUSTOM_FRONTEND_DIRECTORY']:
+    if not settings.CUSTOM_FRONTEND_DIRECTORY:
         return '', 200
     try:
         return send_from_directory(
-            os.path.join(app.config['CUSTOM_FRONTEND_DIRECTORY'], 'modules'),
+            os.path.join(settings.CUSTOM_FRONTEND_DIRECTORY, 'modules'),
             path
         )
     except NotFound:
@@ -83,23 +84,23 @@ def custom_modules(path):
         return '', 200
 
 
-@app.route('/custom/styles/<path:path>')
+@blueprint.route('/custom/styles/<path:path>')
 @authnz.require_auth
 def custom_styles(path):
-    if not app.config['CUSTOM_FRONTEND_DIRECTORY']:
+    if not settings.CUSTOM_FRONTEND_DIRECTORY:
         return '', 404
     return send_from_directory(
-        os.path.join(app.config['CUSTOM_FRONTEND_DIRECTORY'], 'styles'),
+        os.path.join(settings.CUSTOM_FRONTEND_DIRECTORY, 'styles'),
         path
     )
 
 
-@app.route('/custom/images/<path:path>')
+@blueprint.route('/custom/images/<path:path>')
 @authnz.require_auth
 def custom_images(path):
-    if not app.config['CUSTOM_FRONTEND_DIRECTORY']:
+    if not settings.CUSTOM_FRONTEND_DIRECTORY:
         return '', 404
     return send_from_directory(
-        os.path.join(app.config['CUSTOM_FRONTEND_DIRECTORY'], 'images'),
+        os.path.join(settings.CUSTOM_FRONTEND_DIRECTORY, 'images'),
         path
     )

--- a/confidant/scripts/bootstrap.py
+++ b/confidant/scripts/bootstrap.py
@@ -9,11 +9,11 @@ from cryptography.fernet import Fernet
 from flask_script import Command, Option
 
 from confidant import settings
-from confidant.app import app
 from confidant.lib import cryptolib
 
-app.logger.addHandler(logging.StreamHandler(sys.stdout))
-app.logger.setLevel(logging.INFO)
+logger = logging.getLogger(__name__)
+logger.addHandler(logging.StreamHandler(sys.stdout))
+logger.setLevel(logging.INFO)
 
 
 class GenerateSecretsBootstrap(Command):
@@ -31,7 +31,7 @@ class GenerateSecretsBootstrap(Command):
                 secrets = f.read()
         data_key = cryptolib.create_datakey(
             {'type': 'bootstrap'},
-            app.config['KMS_MASTER_KEY'],
+            settings.KMS_MASTER_KEY,
         )
         f = Fernet(data_key['plaintext'])
         data = {

--- a/confidant/scripts/manage.py
+++ b/confidant/scripts/manage.py
@@ -1,6 +1,6 @@
 from flask_script import Manager
 
-from confidant import app
+from confidant.app import create_app
 from confidant.scripts.utils import ManageGrants
 from confidant.scripts.utils import RevokeGrants
 from confidant.scripts.utils import CreateDynamoTables
@@ -12,7 +12,8 @@ from confidant.scripts.migrate import (
 )
 from confidant.scripts.migrate_bool import MigrateBooleanAttribute
 
-manager = Manager(app.app)
+app = create_app()
+manager = Manager(app)
 
 # Ensure KMS grants are setup for services
 manager.add_command("manage_kms_auth_grants", ManageGrants)

--- a/confidant/scripts/migrate.py
+++ b/confidant/scripts/migrate.py
@@ -2,7 +2,6 @@ import sys
 import logging
 from flask_script import Command
 
-from confidant.app import app
 from confidant.models.blind_credential import BlindCredential
 from confidant.models.service import Service
 
@@ -12,9 +11,9 @@ from pynamodb.attributes import Attribute, UnicodeAttribute
 from pynamodb.constants import STRING_SET
 from pynamodb.models import Model
 
-
-app.logger.addHandler(logging.StreamHandler(sys.stdout))
-app.logger.setLevel(logging.INFO)
+logger = logging.getLogger(__name__)
+logger.addHandler(logging.StreamHandler(sys.stdout))
+logger.setLevel(logging.INFO)
 
 
 def is_old_unicode_set(values):
@@ -109,7 +108,7 @@ class MigrateBlindCredentialSetAttribute(Command):
     def run(self):
         total = 0
         fail = 0
-        app.logger.info('Migrating UnicodeSetAttribute in BlindCredential')
+        logger.info('Migrating UnicodeSetAttribute in BlindCredential')
         for cred in BlindCredential.data_type_date_index.query(
                 'blind-credential'):
             cred.save()
@@ -125,7 +124,7 @@ class MigrateServiceSetAttribute(Command):
     def run(self):
         total = 0
         fail = 0
-        app.logger.info('Migrating UnicodeSetAttribute in Service')
+        logger.info('Migrating UnicodeSetAttribute in Service')
         for service in Service.data_type_date_index.query(
                 'service'):
             service.save()

--- a/confidant/services/ciphermanager.py
+++ b/confidant/services/ciphermanager.py
@@ -4,7 +4,7 @@ import logging
 
 from cryptography.fernet import Fernet
 
-from confidant.app import app
+from confidant import settings
 
 
 class CipherManager:
@@ -21,7 +21,7 @@ class CipherManager:
 
     def encrypt(self, raw):
         # Disabled encryption is dangerous, so we don't use falsiness here.
-        if app.config['USE_ENCRYPTION'] is False:
+        if settings.USE_ENCRYPTION is False:
             logging.warning('Not using encryption in CipherManager.encrypt'
                             ' If you are not running in a development or test'
                             ' environment, this should not be happening!')
@@ -36,7 +36,7 @@ class CipherManager:
 
     def decrypt(self, enc):
         # Disabled encryption is dangerous, so we don't use falsiness here.
-        if app.config['USE_ENCRYPTION'] is False:
+        if settings.USE_ENCRYPTION is False:
             logging.warning('Not using encryption in CipherManager.decrypt'
                             ' If you are not running in a development or test'
                             ' environment, this should not be happening!')

--- a/confidant/services/credentialmanager.py
+++ b/confidant/services/credentialmanager.py
@@ -2,7 +2,7 @@ import copy
 
 from pynamodb.exceptions import DoesNotExist
 
-from confidant.app import app
+from confidant import settings
 from confidant.utils import stats
 from confidant.models.credential import Credential
 from confidant.models.blind_credential import BlindCredential
@@ -24,7 +24,7 @@ def pair_key_conflicts_for_credentials(credential_ids, blind_credential_ids):
     conflicts = {}
     pair_keys = {}
     # If we don't care about conflicts, return immediately
-    if app.config['IGNORE_CONFLICTS']:
+    if settings.IGNORE_CONFLICTS:
         return conflicts
     # For all credentials, get their credential pairs and track which
     # credentials have which keys

--- a/confidant/services/graphite.py
+++ b/confidant/services/graphite.py
@@ -2,16 +2,16 @@ import requests
 import json
 import logging
 
-from confidant.app import app
+from confidant import settings
 
 
 def send_event(services, msg):
     try:
-        graphite_url = app.config.get('GRAPHITE_EVENT_URL')
+        graphite_url = settings.GRAPHITE_EVENT_URL
         if not graphite_url:
             return
-        username = app.config.get('GRAPHITE_USERNAME')
-        password = app.config.get('GRAPHITE_PASSWORD')
+        username = settings.GRAPHITE_USERNAME
+        password = settings.GRAPHITE_PASSWORD
         headers = {'Content-type': 'application/json', 'Accept': 'text/plain'}
         prefixed_services = ['confidant-{0}'.format(service)
                              for service in services]

--- a/confidant/services/servicemanager.py
+++ b/confidant/services/servicemanager.py
@@ -1,6 +1,6 @@
 from pynamodb.exceptions import DoesNotExist
 
-from confidant.app import app
+from confidant import settings
 from confidant.services import credentialmanager
 from confidant.services import graphite
 from confidant.models.service import Service
@@ -47,7 +47,7 @@ def get_service_map(services):
 def pair_key_conflicts_for_services(_id, credential_keys, services):
     conflicts = {}
     # If we don't care about conflicts, return immediately
-    if app.config['IGNORE_CONFLICTS']:
+    if settings.IGNORE_CONFLICTS:
         return conflicts
     service_map = get_service_map(services)
     credential_ids = []

--- a/confidant/services/webhook.py
+++ b/confidant/services/webhook.py
@@ -2,17 +2,17 @@ import requests
 import json
 import logging
 
-from confidant.app import app
+from confidant import settings
 
 
 def send_event(event_type, services, credential_ids):
     try:
-        webhook_url = app.config.get('WEBHOOK_URL')
+        webhook_url = settings.WEBHOOK_URL
         if not webhook_url:
             logging.debug('Failed to find a WEBHOOK_URL in config')
             return
-        username = app.config.get('WEBHOOK_USERNAME')
-        password = app.config.get('WEBHOOK_PASSWORD')
+        username = settings.WEBHOOK_USERNAME
+        password = settings.WEBHOOK_PASSWORD
         headers = {'Content-type': 'application/json', 'Accept': 'text/plain'}
 
         event = {

--- a/confidant/utils/__init__.py
+++ b/confidant/utils/__init__.py
@@ -1,9 +1,9 @@
 import statsd
 
-from confidant.app import app
+from confidant import settings
 
 stats = statsd.StatsClient(
-    app.config['STATSD_HOST'],
-    app.config['STATSD_PORT'],
+    settings.STATSD_HOST,
+    settings.STATSD_PORT,
     prefix='confidant'
 )

--- a/confidant/utils/maintenance.py
+++ b/confidant/utils/maintenance.py
@@ -5,14 +5,14 @@ from functools import wraps
 
 from flask import make_response
 
-from confidant.app import app
+from confidant import settings
 
 
 def in_maintenance_mode():
     # We're in maintenance mode if the config option is explicitly set, or if
     # the touch file exists.
-    maintenance_mode = app.config['MAINTENANCE_MODE']
-    _maintenance_touch_file = app.config['MAINTENANCE_MODE_TOUCH_FILE']
+    maintenance_mode = settings.MAINTENANCE_MODE
+    _maintenance_touch_file = settings.MAINTENANCE_MODE_TOUCH_FILE
     if _maintenance_touch_file and os.path.exists(_maintenance_touch_file):
         maintenance_mode = True
     return maintenance_mode

--- a/confidant/wsgi.py
+++ b/confidant/wsgi.py
@@ -1,20 +1,10 @@
 import gevent
-import guard
 
 from confidant import settings
 from confidant.app import create_app  # noqa
 from confidant.services import iamrolemanager
 
-CSP_POLICY = {
-    'default-src': ["'self'"],
-    'style-src': [
-        "'self'",
-        "'unsafe-inline'"  # for spin.js
-    ]
-}
-
 app = create_app()
-app.wsgi_app = guard.ContentSecurityPolicy(app.wsgi_app, CSP_POLICY)
 
 if settings.BACKGROUND_CACHE_IAM_ROLES:
     gevent.spawn(iamrolemanager.refresh_cache)

--- a/confidant/wsgi.py
+++ b/confidant/wsgi.py
@@ -1,9 +1,8 @@
 import gevent
 import guard
 
-from confidant.app import app  # noqa
-from confidant import routes  # noqa
 from confidant import settings
+from confidant.app import create_app  # noqa
 from confidant.services import iamrolemanager
 
 CSP_POLICY = {
@@ -14,6 +13,7 @@ CSP_POLICY = {
     ]
 }
 
+app = create_app()
 app.wsgi_app = guard.ContentSecurityPolicy(app.wsgi_app, CSP_POLICY)
 
 if settings.BACKGROUND_CACHE_IAM_ROLES:

--- a/dev_wsgi.py
+++ b/dev_wsgi.py
@@ -1,9 +1,10 @@
+from confidant import settings
 from confidant.app import create_app
 
 if __name__ == '__main__':
     app = create_app()
     app.run(
-        host=app.config.get('HOST', '127.0.0.1'),
-        port=app.config.get('PORT', 5000),
-        debug=app.config.get('DEBUG', True)
+        host=settings.get('HOST', '127.0.0.1'),
+        port=settings.get('PORT', 5000),
+        debug=settings.get('DEBUG', True)
     )

--- a/dev_wsgi.py
+++ b/dev_wsgi.py
@@ -1,6 +1,7 @@
-from confidant.app import app
+from confidant.app import create_app
 
 if __name__ == '__main__':
+    app = create_app()
     app.run(
         host=app.config.get('HOST', '127.0.0.1'),
         port=app.config.get('PORT', 5000),

--- a/tests/integration/confidant/authnz/authnz_test.py
+++ b/tests/integration/confidant/authnz/authnz_test.py
@@ -3,6 +3,7 @@ import base64
 from mock import patch
 from mock import PropertyMock
 
+from confidant import settings
 from confidant.wsgi import app
 from confidant.authnz import userauth
 from confidant import routes  # noqa
@@ -12,27 +13,27 @@ class AuthnzTest(unittest.TestCase):
 
     def setUp(self):
         self.test_client = app.test_client()
-        self.email_suffix = app.config['USER_EMAIL_SUFFIX']
-        app.config['USER_EMAIL_SUFFIX'] = ''
-        self.use_auth = app.config['USE_AUTH']
-        self.users_file = app.config['USERS_FILE']
+        self.email_suffix = settings.USER_EMAIL_SUFFIX
+        settings.USER_EMAIL_SUFFIX = ''
+        self.use_auth = settings.USE_AUTH
+        self.users_file = settings.USERS_FILE
         self.debug = app.debug
 
     def tearDown(self):
-        app.config['USER_EMAIL_SUFFIX'] = self.email_suffix
-        app.config['USE_AUTH'] = self.use_auth
-        app.config['USERS_FILE'] = self.users_file
+        settings.USER_EMAIL_SUFFIX = self.email_suffix
+        settings.USE_AUTH = self.use_auth
+        settings.USERS_FILE = self.users_file
         app.debug = self.debug
 
     def test_auth_redirect(self):
         app.debug = True
-        app.config['USE_AUTH'] = True
+        settings.USE_AUTH = True
         ret = self.test_client.get('/', follow_redirects=False)
         self.assertEquals(ret.status_code, 302)
 
     def test_no_auth(self):
         app.debug = True
-        app.config['USE_AUTH'] = False
+        settings.USE_AUTH = False
         user_mod = userauth.init_user_auth_class()
         with patch('confidant.authnz.user_mod', user_mod):
             ret = self.test_client.get('/v1/user/email')
@@ -40,15 +41,15 @@ class AuthnzTest(unittest.TestCase):
 
     def test_auth_failure(self):
         app.debug = True
-        app.config['USE_AUTH'] = True
+        settings.USE_AUTH = True
         ret = self.test_client.get('/v1/user/email', follow_redirects=False)
         self.assertEquals(ret.status_code, 401)
 
     def test_auth_with_email_session_in_users(self):
         app.debug = True
-        app.config['USE_AUTH'] = True
+        settings.USE_AUTH = True
         # USERS_FILE needs to be set to test users file
-        app.config['USERS_FILE'] = ''
+        settings.USERS_FILE = ''
         to_patch = ('confidant.authnz.userauth.AbstractUserAuthenticator.'
                     'allowed_email_whitelist')
         with patch(to_patch, new_callable=PropertyMock) as mock_whitelist:
@@ -64,9 +65,9 @@ class AuthnzTest(unittest.TestCase):
 
     def test_auth_with_email_session_not_in_users(self):
         app.debug = True
-        app.config['USE_AUTH'] = True
+        settings.USE_AUTH = True
         # USERS_FILE needs to be set to test users file
-        app.config['USERS_FILE'] = ''
+        settings.USERS_FILE = ''
         to_patch = ('confidant.authnz.userauth.AbstractUserAuthenticator.'
                     'allowed_email_whitelist')
         with patch(to_patch, new_callable=PropertyMock) as mock_whitelist:
@@ -83,8 +84,8 @@ class AuthnzTest(unittest.TestCase):
     def test_auth_with_email_session(self):
         app.debug = True
         # Unset the USERS_FILE, in case it's been set elsewhere
-        app.config['USERS_FILE'] = ''
-        app.config['USE_AUTH'] = True
+        settings.USERS_FILE = ''
+        settings.USE_AUTH = True
         to_patch = ('confidant.authnz.userauth.AbstractUserAuthenticator.'
                     'allowed_email_whitelist')
         with patch(to_patch, new_callable=PropertyMock) as mock_whitelist:
@@ -100,11 +101,11 @@ class AuthnzTest(unittest.TestCase):
 
     def test_header_csrf(self):
         app.debug = True
-        app.config['USE_AUTH'] = True
-        app.config['USER_AUTH_MODULE'] = 'header'
-        app.config['HEADER_AUTH_USERNAME_HEADER'] = 'X-Confidant-User'
-        app.config['HEADER_AUTH_EMAIL_HEADER'] = 'X-Confidant-Email'
-        app.config['XSRF_COOKIE_NAME'] = 'XSRF-TOKEN'
+        settings.USE_AUTH = True
+        settings.USER_AUTH_MODULE = 'header'
+        settings.HEADER_AUTH_USERNAME_HEADER = 'X-Confidant-User'
+        settings.HEADER_AUTH_EMAIL_HEADER = 'X-Confidant-Email'
+        settings.XSRF_COOKIE_NAME = 'XSRF-TOKEN'
         user_mod = userauth.init_user_auth_class()
         with patch('confidant.authnz.user_mod', user_mod):
             ret = self.test_client.get(
@@ -128,7 +129,7 @@ class AuthnzTest(unittest.TestCase):
 
     def test_invalid_kms_auth_token(self):
         app.debug = True
-        app.config['USE_AUTH'] = True
+        settings.USE_AUTH = True
         auth = base64.b64encode(b'confidant-development:faketoken').decode()
         ret = self.test_client.get(
             '/v1/services/confidant-development',

--- a/tests/integration/confidant/authnz/authnz_test.py
+++ b/tests/integration/confidant/authnz/authnz_test.py
@@ -3,7 +3,7 @@ import base64
 from mock import patch
 from mock import PropertyMock
 
-from confidant.app import app
+from confidant.wsgi import app
 from confidant.authnz import userauth
 from confidant import routes  # noqa
 

--- a/tests/unit/confidant/services/keymanager_test.py
+++ b/tests/unit/confidant/services/keymanager_test.py
@@ -6,20 +6,21 @@ from mock import patch
 from confidant import settings
 settings.encrypted_settings.secret_string = {}
 
+from confidant import settings  # noqa:E402
 from confidant.services import keymanager  # noqa:E402
-from confidant.app import app  # noqa:E402
+from confidant.wsgi import app  # noqa:E402
 
 
 class KeyManagerTest(unittest.TestCase):
     def setUp(self):
-        self.use_auth = app.config['USE_AUTH']
-        self.use_encryption = app.config['USE_ENCRYPTION']
-        self.scoped_auth_keys = app.config['SCOPED_AUTH_KEYS']
+        self.use_auth = settings.USE_AUTH
+        self.use_encryption = settings.USE_ENCRYPTION
+        self.scoped_auth_keys = settings.SCOPED_AUTH_KEYS
 
     def tearDown(self):
-        app.config['USE_AUTH'] = self.use_auth
-        app.config['USE_ENCRYPTION'] = self.use_encryption
-        app.config['SCOPED_AUTH_KEYS'] = self.scoped_auth_keys
+        settings.USE_AUTH = self.use_auth
+        settings.USE_ENCRYPTION = self.use_encryption
+        settings.SCOPED_AUTH_KEYS = self.scoped_auth_keys
 
     @patch('confidant.services.keymanager.KEY_METADATA', {})
     @patch('confidant.services.keymanager.auth_kms_client.describe_key')
@@ -43,7 +44,7 @@ class KeyManagerTest(unittest.TestCase):
 
     @patch('cryptography.fernet.Fernet.generate_key')
     def test_create_datakey_mocked(self, fernet_mock):
-        app.config['USE_ENCRYPTION'] = False
+        settings.USE_ENCRYPTION = False
         fernet_mock.return_value = 'mocked_fernet_key'
 
         ret = keymanager.create_datakey({})
@@ -58,7 +59,7 @@ class KeyManagerTest(unittest.TestCase):
         self.assertEquals(ret['ciphertext'], 'mocked_fernet_key')
 
     def test_decrypt_datakey_mocked(self):
-        app.config['USE_ENCRYPTION'] = False
+        settings.USE_ENCRYPTION = False
         ret = keymanager.decrypt_datakey('mocked_fernet_key')
 
         # Ensure we get the same value out that we sent in.
@@ -71,7 +72,7 @@ class KeyManagerTest(unittest.TestCase):
         'confidant.services.keymanager.cryptolib.create_mock_datakey'
     )
     def test_create_datakey_with_encryption(self, cmd_mock, cd_mock):
-        app.config['USE_ENCRYPTION'] = True
+        settings.USE_ENCRYPTION = True
         context = {'from': 'confidant-development',
                    'to': 'confidant-development'}
         keymanager.create_datakey(context)
@@ -88,7 +89,7 @@ class KeyManagerTest(unittest.TestCase):
         'confidant.services.keymanager.cryptolib.decrypt_mock_datakey'
     )
     def test_decrypt_datakey_with_encryption(self, dmd_mock, dd_mock):
-        app.config['USE_ENCRYPTION'] = True
+        settings.USE_ENCRYPTION = True
         context = {'from': 'confidant-development',
                    'to': 'confidant-development'}
         keymanager.decrypt_datakey(b'encrypted', context)


### PR DESCRIPTION
This change updates how the app is created for initialization, for easier testing. A change needed to switch to blueprints is to no longer use `app.config['<var>']`, but instead to use `settings.<var>`. This change also updates the encrypted settings and allows access directly to the encrypted settings from the settings variables.