### PR TITLE
Add unit test coverage for authnz init module

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,7 @@ max-line-length = 80
 exclude = .git,__pycache__,venv,tests/,.ropeproject
 
 [coverage:report]
-fail_under = 38
+fail_under = 42
 
 [coverage:html]
 directory = build/coverage_html

--- a/tests/unit/confidant/authnz/authnz_test.py
+++ b/tests/unit/confidant/authnz/authnz_test.py
@@ -1,8 +1,8 @@
 import pytest
-from werkzeug.exceptions import Unauthorized
+from werkzeug.exceptions import Forbidden, Unauthorized
 
-from confidant.app import create_app
 from confidant import authnz
+from confidant.app import create_app
 
 
 @pytest.fixture(autouse=True)
@@ -103,6 +103,66 @@ def test_user_is_service(mocker):
     assert authnz.user_is_service('notconfidant-unitttest') is False
 
 
+def test_service_in_account(mocker):
+    # If we aren't scoping, this should pass
+    assert authnz.service_in_account(None) is True
+
+    g_mock = mocker.patch('confidant.authnz.g')
+    g_mock.account = 'confidant-unitttest'
+    assert authnz.service_in_account('bad-service') is False
+    assert authnz.service_in_account('confidant-unitttest') is True
+
+
+def test_account_for_key_alias(mocker):
+    mocker.patch(
+        'confidant.authnz.settings.SCOPED_AUTH_KEYS',
+        {'sandbox-auth-key': 'sandbox'},
+    )
+    assert authnz.account_for_key_alias('sandbox-auth-key') == 'sandbox'
+    assert authnz.account_for_key_alias('non-existent') is None
+
+
+def test__get_kms_auth_data_from_auth(mocker):
+    auth_mock = mocker.patch('confidant.authnz.request')
+    expected = {
+        'username': 'test-user',
+        'token': 'test-token',
+    }
+    auth_mock.authorization = {
+        'username': expected['username'],
+        'password': expected['token'],
+    }
+    auth_mock.headers = None
+    assert authnz._get_kms_auth_data() == expected
+
+    auth_mock.authorization = {
+        'username': expected['username'],
+    }
+    with pytest.raises(authnz.AuthenticationError):
+        authnz._get_kms_auth_data()
+
+
+def test__get_kms_auth_data_from_headers(mocker):
+    auth_mock = mocker.patch('confidant.authnz.request')
+    expected = {
+        'username': 'test-user',
+        'token': 'test-token',
+    }
+    auth_mock.headers = {
+        'X-Auth-From': expected['username'],
+        'X-Auth-Token': expected['token'],
+    }
+    auth_mock.authorization = None
+    assert authnz._get_kms_auth_data() == expected
+
+    auth_mock.headers = {
+        'X-Auth-From': expected['username'],
+        'X-Auth-Token': None,
+    }
+    with pytest.raises(authnz.AuthenticationError):
+        authnz._get_kms_auth_data()
+
+
 def test_redirect_to_logout_if_no_auth(mocker):
     mock_fn = mocker.Mock()
     mock_fn.__name__ = 'mock_fn'
@@ -173,3 +233,148 @@ def test_header_auth_will_log_in(mocker, mock_header_auth):
 
         assert resp.status_code == 302
         assert resp.headers['Location'] == '/'
+
+
+def test_require_auth(mocker):
+    mocker.patch(
+        'confidant.authnz.settings.KMS_AUTH_USER_TYPES',
+        ['user', 'service'],
+    )
+
+    mock_fn = mocker.Mock()
+    mock_fn.__name__ = 'mock_fn'
+    mock_fn.return_value = 'unittestval'
+
+    wrapped = authnz.require_auth(mock_fn)
+    mocker.patch('confidant.authnz.settings.USE_AUTH', False)
+    assert wrapped() == 'unittestval'
+
+    mocker.patch('confidant.authnz.settings.USE_AUTH', True)
+    mocker.patch(
+        'confidant.authnz._get_kms_auth_data',
+        mocker.Mock(side_effect=authnz.AuthenticationError()),
+    )
+    with pytest.raises(Forbidden):
+        wrapped()
+
+    def extract_username_field(username, field):
+        username_arr = username.split('/')
+        if field == 'from':
+            return username_arr[2]
+        elif field == 'user_type':
+            return username_arr[1]
+
+    validator_mock = mocker.MagicMock()
+    mocker.patch('confidant.authnz._get_validator', return_value=validator_mock)
+    validator_mock.extract_username_field = extract_username_field
+
+    mocker.patch(
+        'confidant.authnz._get_kms_auth_data',
+        return_value={
+            'username': '2/badusertype/test-user',
+            'token': 'test-token',
+        },
+    )
+    with pytest.raises(Forbidden):
+        wrapped()
+
+    mocker.patch(
+        'confidant.authnz._get_kms_auth_data',
+        return_value={
+            'username': '2/service/test-user',
+            'token': 'test-token',
+        },
+    )
+    validator_mock.decrypt_token = mocker.Mock(
+        side_effect=authnz.kmsauth.TokenValidationError
+    )
+    with pytest.raises(Forbidden):
+        wrapped()
+
+    validator_mock.decrypt_token = mocker.Mock(
+        return_value={'payload': {}, 'key_alias': 'testkey'},
+    )
+    mocker.patch(
+        'confidant.authnz.user_type_has_privilege',
+        return_value=False,
+    )
+    with pytest.raises(Forbidden):
+        wrapped()
+
+    mocker.patch('confidant.authnz.user_type_has_privilege', return_value=True)
+    mocker.patch('confidant.authnz.account_for_key_alias', return_value=None)
+
+    g_mock = mocker.patch('confidant.authnz.g')
+    assert wrapped() == 'unittestval'
+    assert g_mock.user_type == 'service'
+    assert g_mock.auth_type == 'kms'
+    assert g_mock.username == 'test-user'
+
+    mocker.patch(
+        'confidant.authnz._get_kms_auth_data',
+        return_value={},
+    )
+    mocker.patch('confidant.authnz.user_type_has_privilege', return_value=False)
+    with pytest.raises(Forbidden):
+        wrapped()
+
+    mocker.patch('confidant.authnz.user_type_has_privilege', return_value=True)
+    user_mod = mocker.MagicMock()
+    mocker.patch('confidant.authnz.user_mod', user_mod)
+    user_mod.is_expired = mocker.Mock(return_value=True)
+    with pytest.raises(Unauthorized):
+        wrapped()
+
+    user_mod.is_expired = mocker.Mock(return_value=False)
+    user_mod.is_authenticated = mocker.Mock(return_value=False)
+    with pytest.raises(Unauthorized):
+        wrapped()
+
+    user_mod.is_authenticated = mocker.Mock(return_value=True)
+    user_mod.check_authorization = mocker.Mock(return_value=None)
+    user_mod.auth_type = 'testmod'
+    user_mod.set_expiration = mocker.Mock()
+    response = mocker.Mock()
+    mocker.patch('confidant.authnz.make_response', return_value=response)
+    user_mod.set_csrf_token = mocker.Mock()
+    assert wrapped() == response
+    assert g_mock.user_type == 'user'
+    assert g_mock.auth_type == 'testmod'
+
+    user_mod.check_authorization = mocker.Mock(side_effect=authnz.NotAuthorized)
+    with pytest.raises(Forbidden):
+        wrapped()
+
+
+def test_require_logout_for_goodbye(mocker):
+    mock_fn = mocker.Mock()
+    mock_fn.__name__ = 'mock_fn'
+    mock_fn.return_value = 'unittestval'
+
+    wrapped = authnz.require_logout_for_goodbye(mock_fn)
+
+    mocker.patch('confidant.authnz.settings.USE_AUTH', False)
+    assert wrapped() == 'unittestval'
+
+    mocker.patch('confidant.authnz.settings.USE_AUTH', True)
+    u_mock = mocker.patch('confidant.authnz.user_mod')
+    mocker.patch(
+        'confidant.authnz.get_logged_in_user',
+        mocker.Mock(side_effect=authnz.UserUnknownError()),
+    )
+    assert wrapped() == 'unittestval'
+
+    mocker.patch(
+        'confidant.authnz.get_logged_in_user',
+        mocker.Mock(return_value=True),
+    )
+    response = mocker.MagicMock()
+    response.headers = {'Location': 'http://example.com'}
+    u_mock.log_out = mocker.Mock(return_value=response)
+    mocker.patch(
+        'confidant.authnz.url_for',
+        return_value='http://bad.example.com',
+    )
+    assert wrapped() == response
+    mocker.patch('confidant.authnz.url_for', return_value='http://example.com')
+    assert wrapped() == 'unittestval'


### PR DESCRIPTION
This change adds full coverage for `confidant/authnz/__init__.py`