### PR TITLE
Separate create service rbac check into its own call

### DIFF
--- a/confidant/routes/services.py
+++ b/confidant/routes/services.py
@@ -313,6 +313,7 @@ def map_service_credentials(id):
         service.blind_credentials,
     )
     permissions = {
+        'create': True,
         'metadata': True,
         'get': True,
         'update': True,

--- a/confidant/routes/services.py
+++ b/confidant/routes/services.py
@@ -215,6 +215,18 @@ def map_service_credentials(id):
         revision = 1
         _service = None
 
+    if revision == 1 and not acl_module_check(
+          resource_type='service',
+          action='create',
+          resource_id=id,
+    ):
+        msg = "{} does not have access to create service {}".format(
+            authnz.get_logged_in_user(),
+            id
+        )
+        error_msg = {'error': msg, 'reference': id}
+        return jsonify(error_msg), 403
+
     data = request.get_json()
     credentials = data.get('credentials', [])
     blind_credentials = data.get('blind_credentials', [])
@@ -227,10 +239,9 @@ def map_service_credentials(id):
               'credential_ids': combined_credentials,
           }
     ):
-        msg = "{} does not have access to map service credential {}".format(
-            authnz.get_logged_in_user(),
-            id
-        )
+        msg = "{} does not have access to map the credentials " \
+              "because they do not own the credentials being added"\
+            .format(authnz.get_logged_in_user())
         error_msg = {'error': msg, 'reference': id}
         return jsonify(error_msg), 403
 

--- a/tests/unit/confidant/services/credentialmanager_test.py
+++ b/tests/unit/confidant/services/credentialmanager_test.py
@@ -22,6 +22,24 @@ def test_get_latest_credential_revision(mocker):
     assert res == 2
 
 
+def test_check_credential_pair_values(mocker):
+    cred_pairs_success = {
+        'A': '1'
+    }
+    cred_pairs_fail = {
+        'A': ['1', '2', '3']
+    }
+    cred_pair_fail_2 = {
+        'A': {'1': '2'}
+    }
+    result = credentialmanager.check_credential_pair_values(cred_pairs_fail)
+    assert result[0] is False
+    result = credentialmanager.check_credential_pair_values(cred_pair_fail_2)
+    assert result[0] is False
+    result = credentialmanager.check_credential_pair_values(cred_pairs_success)
+    assert result[0] is True
+
+
 def test_lowercase_credential_pairs():
     test = {
         'A': '123',


### PR DESCRIPTION
- Check that a user is able to create a service before calling the rbac check to determine if they're able to map credentials
- Small wording changes on mapping credential deny
- additional unit testing in credential manager