### PR TITLE
Fix update credential not returning credential_response

### DIFF
--- a/confidant/routes/credentials.py
+++ b/confidant/routes/credentials.py
@@ -410,7 +410,7 @@ def update_credential(id):
         include_credential_pairs=True,
     )
     credential_response.permissions = permissions
-    return credential_response_schema.dumps(permissions)
+    return credential_response_schema.dumps(credential_response)
 
 
 @blueprint.route('/v1/credentials/<id>/<to_revision>', methods=['PUT'])


### PR DESCRIPTION
Bug in `update_credential` API endpoint.  Currently after an update of an existing credential, we return the incorrect object thus users will see no credential pairs (see screenshot).

<img width="811" alt="Screen Shot 2020-01-14 at 11 28 16 AM" src="https://user-images.githubusercontent.com/3451399/72375540-1d840200-36c1-11ea-822a-22f771cfaa48.png">

Solution: Return the credentials instead of just permissions after an update. 