### PR TITLE
Python3 compatibility fixes for flask-session

### DIFF
--- a/confidant/app.py
+++ b/confidant/app.py
@@ -44,7 +44,7 @@ def create_app():
 
     if settings.REDIS_URL:
         import redis
-        from flask.ext.session import Session
+        from flask_session import Session
         app.config['SESSION_REDIS'] = redis.Redis.from_url(
             settings.REDIS_URL
         )

--- a/requirements.in
+++ b/requirements.in
@@ -48,7 +48,7 @@ cffi>1.10.0
 # License: BSD
 # Upstream url: https://github.com/fengsp/flask-session
 # Use: For shared sessions
-Flask-Session==0.2.1
+Flask-Session==0.2.3
 
 # Redis
 # License: MIT

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ defusedxml==0.6.0         # via python3-saml
 docutils==0.15.2          # via botocore
 enum34==1.1.6             # via cryptography
 flask-script==2.0.5
-flask-session==0.2.1
+flask-session==0.2.3
 flask-sslify==0.1.5
 flask==1.1.1
 funcsigs==1.0.2           # via mock, pytest

--- a/requirements3.txt
+++ b/requirements3.txt
@@ -19,7 +19,7 @@ cryptography==2.7
 defusedxml==0.6.0         # via python3-saml
 docutils==0.15.2          # via botocore
 flask-script==2.0.5
-flask-session==0.2.1
+flask-session==0.2.3
 flask-sslify==0.1.5
 flask==1.1.1
 gevent==1.2.1


### PR DESCRIPTION
This PR addressing the following issues:
- `flask.ext.session` -> `flask_session` fixes `ImportError: No module named 'flask.ext'` as the old format `flask.ext.*` is deprecated, see: https://github.com/pallets/flask/issues/1135#issuecomment-61860862
- Version bump from `0.2.1` to `0.2.3` address number of issues with Python 3, see changeset: https://github.com/fengsp/flask-session/blob/master/CHANGES#L31:L37. Here is also a stacktrace I've encountered when I was running `confidant` with `flask-session 0.2.1` with Python 3.7 and Redis as a session storage. 

```
 [2020-02-07 23:06:02.669077] ERROR:confidant.app:Exception on /v1/services [GET]
 [2020-02-07 23:06:02.669105] Traceback (most recent call last):
 [2020-02-07 23:06:02.669214]   File "/vendor3/lib/python3.7/site-packages/flask/app.py", line 2445, in wsgi_app
 [2020-02-07 23:06:02.669260]     ctx.push()
 [2020-02-07 23:06:02.669311]   File “/vendor3/lib/python3.7/site-packages/flask/ctx.py", line 390, in push
 [2020-02-07 23:06:02.669351]     self.session = session_interface.open_session(self.app, self.request)
 [2020-02-07 23:06:02.669608]   File "/vendor3/lib/python3.7/site-packages/flask_session/sessions.py", line 118, in open_session
 [2020-02-07 23:06:02.669662]     val = self.redis.get(self.key_prefix + sid)
 [2020-02-07 23:06:02.669714] TypeError: can only concatenate str (not "bytes") to str
 [2020-02-07 23:06:02.669755] ERROR:confidant.app:Request finalizing failed with an error while handling an error
```

  