### PR TITLE
Bump gevent and greenlet dependencies for Python 3.7 compatibility

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -37,16 +37,19 @@ jobs:
   #      run: license_finder
   test:
     runs-on: ubuntu-18.04
+    strategy:
+        matrix:
+          python-version: ['3.6.x', '3.7.x']
     steps:
       - name: Checkout
         uses: actions/checkout@v1
       - uses: actions/setup-node@v1
         with:
           node-version: '8.x'
-      - name: Setup python 3.6
+      - name: Setup python ${{ matrix.python-version }}
         uses: actions/setup-python@v1
         with:
-          python-version: 3.6
+          python-version: ${{ matrix.python-version }}
       - name: Install apt dependencies
         run: sudo apt-get update && sudo apt-get install -y python3-dev openssl libssl-dev gcc pkg-config libffi-dev libxml2-dev libxmlsec1-dev
       - name: Install dependencies

--- a/requirements.in
+++ b/requirements.in
@@ -119,12 +119,12 @@ gunicorn>=19.9.0,<20.0.0
 # License: MIT
 # Upstream url: http://www.gevent.org/
 # Use: For concurrency
-gevent==1.2.1
+gevent==1.4.0
 
 # License: MIT
 # Upstream url: https://github.com/python-greenlet/greenlet
 # Use: For concurrency
-greenlet==0.4.12
+greenlet==0.4.15
 
 # License: MIT
 # Upstream url: https://github.com/jsocol/pystatsd

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,8 +27,8 @@ flask-sslify==0.1.5
 flask==1.1.1
 funcsigs==1.0.2           # via mock, pytest
 futures==3.3.0            # via s3transfer
-gevent==1.2.1
-greenlet==0.4.12
+gevent==1.4.0
+greenlet==0.4.15
 guard==1.0.1
 gunicorn==19.9.0
 idna==2.8                 # via requests

--- a/requirements3.txt
+++ b/requirements3.txt
@@ -22,8 +22,8 @@ flask-script==2.0.5
 flask-session==0.2.3
 flask-sslify==0.1.5
 flask==1.1.1
-gevent==1.2.1
-greenlet==0.4.12
+gevent==1.4.0
+greenlet==0.4.15
 guard==1.0.1
 gunicorn==19.9.0
 idna==2.8                 # via requests


### PR DESCRIPTION
During the rollout of `confidant 5.2.0` we ran into a number of issues with Python 3.7.

First of all `pypi` does not have python3.7 binaries for `gevent 1.2.1`: https://pypi.org/project/gevent/1.2.1/#files and same for `greenlet 0.4.12`: https://pypi.org/project/greenlet/0.4.12/#files

I tried bumping `gevent` to `1.3.0` and `greenlet` to `0.4.14`, but `gevent` workers were segfaulting after the startup with the following log statements:
```
[18839] [CRITICAL] WORKER TIMEOUT (pid:20879)
```
 After enabling https://docs.python.org/3/library/faulthandler.html we were able to get the actual stacktrace:

```
[2020-02-05 00:17:00.379340] Fatal Python error: Segmentation fault
[2020-02-05 00:17:00.379513] 
[2020-02-05 00:17:00.379578] Thread 0x00007fd427e5c700 (most recent call first):
[2020-02-05 00:17:00.380093]   File "/vendor3/lib/python3.7/site-packages/gevent/_threading.py", line 80 in wait
[2020-02-05 00:17:00.380242]   File "/vendor3/lib/python3.7/site-packages/gevent/_threading.py", line 162 in get
[2020-02-05 00:17:00.380312]   File "/vendor3/lib/python3.7/site-packages/gevent/threadpool.py", line 270 in _worker
[2020-02-05 00:17:00.380358] 
[2020-02-05 00:17:00.380410] Current thread 0x00007fd4325e3700 (most recent call first):
[2020-02-05 00:17:00.380481]   File "/confidant/authnz/__init__.py", line 70 in user_is_user_type
[2020-02-05 00:17:00.380554]   File "/confidant/authnz/__init__.py", line 109 in user_is_authorized
[2020-02-05 00:17:00.380613]   File "/confidant/routes/v1.py", line 505 in _get_credentials
[2020-02-05 00:17:00.380673]   File "/confidant/routes/v1.py", line 137 in get_service
[2020-02-05 00:17:00.380730]   File "/confidant/authnz/__init__.py", line 215 in decorated
[2020-02-05 00:17:00.380791]   File "/vendor3/lib/python3.7/site-packages/flask/app.py", line 1935 in dispatch_request
[2020-02-05 00:17:00.380853]   File "/vendor3/lib/python3.7/site-packages/flask/app.py", line 1949 in full_dispatch_request
[2020-02-05 00:17:00.380915]   File "/vendor3/lib/python3.7/site-packages/flask/app.py", line 2446 in wsgi_app
[2020-02-05 00:17:00.381047]   File "/vendor3/lib/python3.7/site-packages/guard.py", line 62 in __call__
[2020-02-05 00:17:00.381204]   File "/vendor3/lib/python3.7/site-packages/flask/app.py", line 2463 in __call__
[2020-02-05 00:17:00.381326]   File "/vendor3/lib/python3.7/site-packages/gunicorn/workers/base_async.py", line 107 in handle_request
[2020-02-05 00:17:00.381422]   File "/vendor3/lib/python3.7/site-packages/gunicorn/workers/ggevent.py", line 160 in handle_request
[2020-02-05 00:17:00.381493]   File "/vendor3/lib/python3.7/site-packages/gunicorn/workers/base_async.py", line 56 in handle
[2020-02-05 00:17:00.381576]   File "/vendor3/lib/python3.7/site-packages/gunicorn/workers/ggevent.py", line 155 in handle
[2020-02-05 00:17:00.381651]   File "/vendor3/lib/python3.7/site-packages/gevent/baseserver.py", line 26 in _handle_and_close_when_done
```

Bumping both dependencies to the latest stable version resolved the segfaults above.