### PR TITLE
Use ACL for both user and service checks

### DIFF
--- a/confidant/authnz/__init__.py
+++ b/confidant/authnz/__init__.py
@@ -1,4 +1,3 @@
-import fnmatch
 import logging
 
 import kmsauth

--- a/confidant/authnz/rbac.py
+++ b/confidant/authnz/rbac.py
@@ -1,3 +1,32 @@
+from confidant import authnz
+
+
+def default_acl(*args, **kwargs):
+    """ Default ACLs for confidant: always return true for users, but enforce
+    ACLs for services, restricting access to:
+
+    * resource_type: service
+      actions: metadata, get
+    """
+    resource_type = kwargs.get('resource_type')
+    action = kwargs.get('action')
+    resource_id = kwargs.get('resource_id')
+    # Some ACL checks also pass extra args in via kwargs, which we would
+    # access via:
+    #    resource_kwargs = kwargs.get('kwargs')
+    if authnz.user_is_user_type('user'):
+        return True
+    elif authnz.user_is_user_type('service'):
+        if resource_type == 'service' and action in ['metadata', 'get']:
+            # Does the resource ID match the authenticated username?
+            if authnz.user_is_service(resource_id):
+                return True
+        # We currently only allow services to access service get/metadata
+        return False
+    else:
+        # This should never happen, but paranoia wins out
+        return False
+
 
 def no_acl(*args, **kwargs):
     """ Stub function that always returns true

--- a/confidant/settings.py
+++ b/confidant/settings.py
@@ -496,4 +496,4 @@ def get(name, default=None):
 
 
 # Module that will perform an external ACL check on API endpoints
-ACL_MODULE = str_env('ACL_MODULE', 'confidant.authnz.rbac:no_acl')
+ACL_MODULE = str_env('ACL_MODULE', 'confidant.authnz.rbac:default_acl')

--- a/pytest.ini
+++ b/pytest.ini
@@ -14,5 +14,6 @@ env =
     KMS_MASTER_KEY=confidant-mastertesting
     DEBUG=true
     STATIC_FOLDER=public
+    ACL_MODULE=confidant.authnz.rbac:default_acl
 norecursedirs = .git
 junit_family = legacy

--- a/tests/unit/confidant/authnz/rbac_test.py
+++ b/tests/unit/confidant/authnz/rbac_test.py
@@ -1,0 +1,70 @@
+from confidant.authnz import rbac
+from confidant.app import create_app
+
+
+def test_default_acl(mocker):
+    app = create_app()
+    with app.test_request_context('/fake'):
+        # Test for user type is user
+        mocker.patch('confidant.authnz.user_is_user_type', return_value=True)
+        assert rbac.default_acl(resource_type='service') is True
+        # Test for user type is service, but not an allowed resource type
+        mocker.patch(
+            'confidant.authnz.user_is_user_type',
+            side_effect=[False, True],
+        )
+        assert rbac.default_acl(
+            resource_type='service', action='update'
+        ) is False
+        # Test for user type is service, and an allowed resource, with metadata
+        # action, but service name doesn't match
+        mocker.patch(
+            'confidant.authnz.user_is_user_type',
+            side_effect=[False, True],
+        )
+        mocker.patch(
+            'confidant.authnz.user_is_service',
+            return_value=False,
+        )
+        assert rbac.default_acl(
+            resource_type='service', action='metadata'
+        ) is False
+        # Test for user type is service, and an allowed resource, with metadata
+        # action
+        mocker.patch(
+            'confidant.authnz.user_is_user_type',
+            side_effect=[False, True],
+        )
+        mocker.patch(
+            'confidant.authnz.user_is_service',
+            return_value=True,
+        )
+        assert rbac.default_acl(
+            resource_type='service', action='metadata'
+        ) is True
+        # Test for user type is service, and an allowed resource, with get
+        # action
+        mocker.patch(
+            'confidant.authnz.user_is_user_type',
+            side_effect=[False, True],
+        )
+        assert rbac.default_acl(resource_type='service', action='get') is True
+        # Test for user type is service, and an allowed resource, with
+        # disallowed fake action
+        mocker.patch(
+            'confidant.authnz.user_is_user_type',
+            side_effect=[False, True],
+        )
+        assert rbac.default_acl(resource_type='service', action='fake') is False
+        # Test for bad user type
+        mocker.patch(
+            'confidant.authnz.user_is_user_type',
+            side_effect=[False, False],
+        )
+        assert rbac.default_acl(resource_type='service', action='get') is False
+
+
+def test_no_acl():
+    app = create_app()
+    with app.test_request_context('/fake'):
+        assert rbac.no_acl(resource_type='service', action='update') is True


### PR DESCRIPTION
This change removes the special-cased code for controlling authz for services, and moves everything to using ACL checks. I've added a new default ACL function `default_acl`, which replicates the default behavior of service authz, while making it possible to fully apply ACL checks against services or users for all resources.