### PR TITLE
Bump authomatic version to 1.0.0

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -70,7 +70,7 @@ Flask-SSLify==0.1.5
 # License: MIT
 # Upstream url: http://peterhudec.github.io/authomatic
 # Use: For google auth
-Authomatic==0.1.0.post1
+Authomatic==1.0.0
 
 # License: MIT
 # Upstream url: https://github.com/onelogin/python3-saml

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@
 asn1crypto==0.24.0        # via cryptography
 atomicwrites==1.3.0       # via pytest
 attrs==19.3.0             # via pytest, toastedmarshmallow
-authomatic==0.1.0.post1
+authomatic==1.0.0
 boto3==1.9.227
 botocore==1.12.227
 certifi==2019.6.16        # via requests

--- a/requirements3.txt
+++ b/requirements3.txt
@@ -7,7 +7,7 @@
 asn1crypto==0.24.0        # via cryptography
 atomicwrites==1.3.0       # via pytest
 attrs==19.3.0             # via pytest, toastedmarshmallow
-authomatic==0.1.0.post1
+authomatic==1.0.0
 boto3==1.9.227
 botocore==1.12.227
 certifi==2019.6.16        # via requests


### PR DESCRIPTION
Google has deprecated their google+ signin APIs, which is what their oauth login used to be based on. They have a new oauth flow, which uses the google sign-in apis. Authomatic, in 1.0.0 release has updated the google provider to support the new API.