### PR TITLE
Populate a credential's tag attribute

### DIFF
--- a/confidant/routes/credentials.py
+++ b/confidant/routes/credentials.py
@@ -609,7 +609,8 @@ def create_credential():
         cipher_version=2,
         modified_by=authnz.get_logged_in_user(),
         documentation=data.get('documentation'),
-        last_rotation_date=last_rotation_date
+        tags=data.get('tags'),
+        last_rotation_date=last_rotation_date,
     ).save(id__null=True)
     # Make this the current revision
     cred = Credential(
@@ -624,7 +625,8 @@ def create_credential():
         cipher_version=2,
         modified_by=authnz.get_logged_in_user(),
         documentation=data.get('documentation'),
-        last_rotation_date=last_rotation_date
+        tags=data.get('tags'),
+        last_rotation_date=last_rotation_date,
     )
     cred.save()
     permissions = {
@@ -780,6 +782,7 @@ def update_credential(id):
         'enabled': _cred.enabled,
         'metadata': data.get('metadata', _cred.metadata),
         'documentation': data.get('documentation', _cred.documentation),
+        'tags': data.get('tags', _cred.tags),
     }
     # Enforce documentation, EXCEPT if we are restoring an old revision
     if (not update['documentation'] and
@@ -845,7 +848,8 @@ def update_credential(id):
             cipher_version=2,
             modified_by=authnz.get_logged_in_user(),
             documentation=update['documentation'],
-            last_rotation_date=update['last_rotation_date']
+            tags=update['tags'],
+            last_rotation_date=update['last_rotation_date'],
         ).save(id__null=True)
     except PutError as e:
         logger.error(e)
@@ -863,7 +867,8 @@ def update_credential(id):
             cipher_version=2,
             modified_by=authnz.get_logged_in_user(),
             documentation=update['documentation'],
-            last_rotation_date=update['last_rotation_date']
+            tags=update['tags'],
+            last_rotation_date=update['last_rotation_date'],
         )
         cred.save()
     except PutError as e:
@@ -1017,6 +1022,7 @@ def revert_credential_to_revision(id, to_revision):
             cipher_version=revert_credential.cipher_version,
             modified_by=authnz.get_logged_in_user(),
             documentation=revert_credential.documentation,
+            tags=revert_credential.tags,
             last_rotation_date=revert_credential.last_rotation_date,
         ).save(id__null=True)
     except PutError as e:
@@ -1035,6 +1041,7 @@ def revert_credential_to_revision(id, to_revision):
             cipher_version=revert_credential.cipher_version,
             modified_by=authnz.get_logged_in_user(),
             documentation=revert_credential.documentation,
+            tags=revert_credential.tags,
             last_rotation_date=revert_credential.last_rotation_date,
         )
         cred.save()

--- a/confidant/schema/credentials.py
+++ b/confidant/schema/credentials.py
@@ -19,6 +19,7 @@ class CredentialResponse(object):
     credential_keys = attr.ib(default=list)
     credential_pairs = attr.ib(default=dict)
     permissions = attr.ib(default=dict)
+    tags = attr.ib(default=list)
 
     @classmethod
     def from_credential(
@@ -36,6 +37,7 @@ class CredentialResponse(object):
             documentation=credential.documentation,
             modified_date=credential.modified_date,
             modified_by=credential.modified_by,
+            tags=credential.tags,
         )
         if include_credential_keys:
             ret.credential_keys = credential.credential_keys
@@ -61,6 +63,7 @@ class CredentialResponseSchema(AutobuildSchema):
     modified_date = fields.DateTime(required=True)
     modified_by = fields.Str(required=True)
     permissions = fields.Dict(keys=fields.Str(), values=fields.Boolean())
+    tags = fields.List(fields.Str())
 
 
 @attr.s

--- a/confidant/settings.py
+++ b/confidant/settings.py
@@ -597,7 +597,7 @@ ROTATION_DAYS_CONFIG = json.loads(str_env('ROTATION_DAYS_CONFIG', '{}'))
 # when credential.credential_pairs is sent back to the client
 # in GET /v1/credentials/<ID> to keep track of when a human
 # last saw a credential pair
-ENABLE_SAVE_LAST_DECRYPTION_TIME = bool_env('ENABLE_SAVE_LAST_DECRYPT_TIME')
+ENABLE_SAVE_LAST_DECRYPTION_TIME = bool_env('ENABLE_SAVE_LAST_DECRYPTION_TIME')
 
 
 # Configuration validation

--- a/tests/unit/confidant/routes/credentials_test.py
+++ b/tests/unit/confidant/routes/credentials_test.py
@@ -41,6 +41,7 @@ def archive_credential(mocker):
         modified_date=datetime.now(),
         modified_by='test@example.com',
         documentation='',
+        tags=['OLD TAG'],
     )
 
 
@@ -378,10 +379,12 @@ def test_create_credential(mocker, credential):
             'documentation': 'doc',
             'credential_pairs': {'key': 'value'},
             'name': 'shiny new key',
+            'tags': ['ADMIN_PRIV', 'MY_SPECIAL_TAG'],
         }),
     )
     json_data = json.loads(ret.data)
     assert ret.status_code == 200
+    assert ['ADMIN_PRIV', 'MY_SPECIAL_TAG'] == json_data['tags']
     assert 'shiny new key' == json_data['name']
     assert mock_save.call_count == 2
 
@@ -500,10 +503,12 @@ def test_update_credential(mocker, credential):
             'credential_pairs': {'key': 'value'},
             'name': 'shiny new name',
             'documentation': 'doc',
+            'tags': ['NEW SPECIAL TAG', 'DB_AUTH'],
         }),
     )
     json_data = json.loads(ret.data)
     assert ret.status_code == 200
+    assert ['NEW SPECIAL TAG', 'DB_AUTH'] == json_data['tags']
     assert 'shiny new name' == json_data['name']
     assert mock_save.call_count == 2
 
@@ -626,5 +631,6 @@ def test_revise_credential(mocker, credential, archive_credential):
     )
     json_data = json.loads(ret.data)
     assert ret.status_code == 200
+    assert ['OLD TAG'] == json_data['tags']
     assert 'Archive credential' == json_data['name']
     assert mock_save.call_count == 2


### PR DESCRIPTION
We haven't set the credential tags attribute that we added in https://github.com/lyft/confidant/pull/270.

- We always populate tags upon creation
- When updating a credential, we update the tags only if the `"tags"` field is present in the request
- When reverting a credential, we use the tag of the revert credential.