### PR TITLE
Only load credential pairs in UI if user asks to unmask or edits

### DIFF
--- a/confidant/models/credential.py
+++ b/confidant/models/credential.py
@@ -53,7 +53,7 @@ class CredentialBase(Model):
     modified_by = UnicodeAttribute()
     documentation = UnicodeAttribute(null=True)
     # Classification info (eg: FINANCIALLY_SENSITIVE)
-    tags = ListAttribute(default=list)
+    tags = ListAttribute(default=list, null=True)
     last_decrypted_date = UTCDateTimeAttribute(null=True)
     last_rotation_date = UTCDateTimeAttribute(null=True)
 

--- a/confidant/models/credential.py
+++ b/confidant/models/credential.py
@@ -53,7 +53,7 @@ class CredentialBase(Model):
     modified_by = UnicodeAttribute()
     documentation = UnicodeAttribute(null=True)
     # Classification info (eg: FINANCIALLY_SENSITIVE)
-    tags = ListAttribute(default=list, null=True)
+    tags = ListAttribute(default=list)
     last_decrypted_date = UTCDateTimeAttribute(null=True)
     last_rotation_date = UTCDateTimeAttribute(null=True)
 

--- a/confidant/public/modules/resources/controllers/CredentialDetailsCtrl.js
+++ b/confidant/public/modules/resources/controllers/CredentialDetailsCtrl.js
@@ -53,6 +53,27 @@
             $scope.credentialId = $stateParams.credentialId;
             $scope.showCredentials = false;
 
+            function populateCredential(credential) {
+                var _credentialPairs = [],
+                    _metadata = [];
+                if (!angular.equals({}, credential.credential_pairs)) {
+                    angular.forEach(credential.credential_pairs, function(value, key) {
+                        this.push({'key': key, 'value': value});
+                    }, _credentialPairs);
+                    credential.credentialPairs = _credentialPairs;
+                }
+                if (credential.credential_keys.length) {
+                    $scope.hasMetadata = true;
+                }
+                angular.forEach(credential.metadata, function(value, key) {
+                    this.push({'key': key, 'value': value});
+                }, _metadata);
+                credential.credentialPairs = _credentialPairs;
+                credential.mungedMetadata = _metadata;
+                $scope.credential = credential;
+                credentialCopy = angular.copy($scope.credential);
+            }
+
             if ($scope.credentialId) {
                 CredentialServices.get({'id': $scope.credentialId}).$promise.then(function(credentialServices) {
                     $scope.credentialServices = credentialServices.services;
@@ -81,27 +102,6 @@
                 credentialCopy = angular.copy($scope.credential);
                 $scope.shown = true;
             }
-
-            function populateCredential(credential) {
-                var _credentialPairs = [],
-                    _metadata = [];
-                if (!angular.equals({}, credential.credential_pairs)) {
-                    angular.forEach(credential.credential_pairs, function(value, key) {
-                        this.push({'key': key, 'value': value});
-                    }, _credentialPairs);
-                    credential.credentialPairs = _credentialPairs;
-                }
-                if (credential.credential_keys.length) {
-                    $scope.hasMetadata = true;
-                }
-                angular.forEach(credential.metadata, function(value, key) {
-                    this.push({'key': key, 'value': value});
-                }, _metadata);
-                credential.credentialPairs = _credentialPairs;
-                credential.mungedMetadata = _metadata;
-                $scope.credential = credential;
-                credentialCopy = angular.copy($scope.credential);
-            };
 
             $scope.showValue = function(credentialPair) {
                 if ($scope.showCredentials) {

--- a/confidant/public/modules/resources/services/credentials.js
+++ b/confidant/public/modules/resources/services/credentials.js
@@ -18,7 +18,7 @@
     }])
 
     .factory('credentials.credential', ['$resource', 'CONFIDANT_URLS', function($resource, CONFIDANT_URLS) {
-        return $resource(CONFIDANT_URLS.CREDENTIAL, {id: '@id', revision: '@revision'}, {
+        return $resource(CONFIDANT_URLS.CREDENTIAL, {id: '@id', revision: '@revision', metadata_only: true}, {
             update: {method: 'PUT', isArray: false},
             revert: {method: 'PUT', isArray: false, url: CONFIDANT_URLS.CREDENTIAL_REVISION}
         });

--- a/confidant/public/modules/resources/views/credential-details.html
+++ b/confidant/public/modules/resources/views/credential-details.html
@@ -32,7 +32,7 @@
 <p>{{ getError }}</p>
 </div>
 <div class="well" ng-hide="getError">
-  <form editable-form name="editableForm" onaftersave="saveCredential()" oncancel="cancel()" shown="{{ shown }}">
+  <form editable-form name="editableForm" onshow="loadCredentials()" onaftersave="saveCredential()" oncancel="cancel()" shown="{{ shown }}">
     <div class="form-group">
       <label for="credentialNameInput">Credential Name</label>
       <span editable-text="credential.name" id="credentialNameInput" e-required>{{ credential.name || 'Not set' }}</span>
@@ -52,7 +52,13 @@
         </div>
     </div>
     <div class="form-group" ng-show="credential.permissions.get || globalPermissions.credentials.create">
-      <label for="credentialPairInputs">Credential Pairs <span class="glyphicon glyphicon-lock"></span></label>
+      <label for="credentialPairInputs">Credential Pairs
+        <span class="glyphicon glyphicon-lock"></span>
+        <span ng-show="!editableForm.$visible">
+          <a ng-click="toggleCredentialMask()" ng-show="!showCredentialPairs && !editableForm.$visible"><span class="glyphicon glyphicon-eye-open"></span></a>
+          <a ng-click="toggleCredentialMask()" ng-show="showCredentialPairs && !editableForm.$visible"><span class="glyphicon glyphicon-eye-close"></span></a>
+        </span>
+      </label>
       <div class="well well-sm" id="credentialPairInputs">
         <div class="row has-margin-bottom-lg">
           <div></div>
@@ -68,10 +74,6 @@
             <div class="row">
               <div class="col-md-10">
                 <span class="dont-break-out" e-class="textarea-fullwidth dont-break-out" editable-textarea="credentialPair.value" e-ng-trim="false" e-rows="5" e-required>{{ showValue(credentialPair) }}</span>
-              </div>
-              <div class="col-md-2" ng-show="!editableForm.$visible">
-                <a ng-click="toggleCredentialMask(credentialPair)" ng-show="!credentialPair.shown && !editableForm.$visible"><span class="glyphicon glyphicon-eye-open"></span></a>
-                <a ng-click="toggleCredentialMask(credentialPair)" ng-show="credentialPair.shown && !editableForm.$visible"><span class="glyphicon glyphicon-eye-close"></span></a>
               </div>
             </div>
           </div>

--- a/confidant/routes/credentials.py
+++ b/confidant/routes/credentials.py
@@ -609,7 +609,7 @@ def create_credential():
         cipher_version=2,
         modified_by=authnz.get_logged_in_user(),
         documentation=data.get('documentation'),
-        tags=data.get('tags'),
+        tags=data.get('tags', []),
         last_rotation_date=last_rotation_date,
     ).save(id__null=True)
     # Make this the current revision
@@ -625,7 +625,7 @@ def create_credential():
         cipher_version=2,
         modified_by=authnz.get_logged_in_user(),
         documentation=data.get('documentation'),
-        tags=data.get('tags'),
+        tags=data.get('tags', []),
         last_rotation_date=last_rotation_date,
     )
     cred.save()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,7 @@ services:
       - saml-idp
     env_file: ./config/development/confidant.env
     volumes:
+      - .:/srv/confidant
       - ./config/development/logging.conf:/etc/confidant/logging.conf
       - ./config/development/idp.crt:/etc/confidant/idp.crt
       - ./config/gunicorn.conf:/etc/confidant/gunicorn.conf


### PR DESCRIPTION
This change improves the auditing and last-viewed behavior of confidant by only fetching decrypted credential pairs when necessary for the UI. If the end-user loads a credential, it loads `metadata_only=True` by default, and if they unmask the credentials, or edit the credential, it'll fetch the credential with `metadata_only=False`, fetching the credential pairs, and replacing them in-place in the view. The view will keep them loaded while in the same credential view, and will not re-fetch the credential for unmask/edit, as long as the user doesn't leave and re-visit the page.