### PR TITLE
Fix links between documents in the docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,7 @@
   the CA in AWS.
 
   The implementation supports multiple CAs. For configuration information, see [the
-  certificate authority settings section in the docs](https://lyft.github.io/confidant/configuration.html#certificate-authority-settings).
+  certificate authority settings section in the docs](configuration.html#certificate-authority-settings).
 
 ## 6.0.0
 
@@ -90,7 +90,7 @@
 * Confidant now includes an access control plugin framework, with a default
   plugin, `confidant.authnz.rbac:default_acl`, which implements the existing
   access control behavior of confidant. The `ACL_MODULE` setting can be used
-  to define your own ACL behavior; see the [ACL docs](https://lyft.github.io/confidant/advanced/acls/)
+  to define your own ACL behavior; see the [ACL docs](acls.html)
   for information about how to apply fine-grained access controls to specific
   resources and actions.
 * kmsauth was upgraded with a more efficient LRU implementation, which allows
@@ -211,7 +211,7 @@ WARNING: If you upgrade to this version, any new writes to blind credentials
 will be in a format that is only compatible in 1.11.0 forward. If you've
 upgraded and need to downgrade, you should downgrade to 1.11.0. This is only
 a concern if you're using blind credentials. If you're using blind credentials,
-see the [upgrade instructions](https://github.com/lyft/confidant/blob/master/docs/source/basics/upgrade.html.markdown)
+see the [upgrade instructions](upgrade.html)
 for more detailed information about this breaking change.
 
 * Added support for a maintenance mode, which will disable all writes to

--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,6 @@ test_frontend:
 compile_deps:
 	./pip-compile.sh
 
-.PHONY: build_docs
-build_docs:
+.PHONY: docs
+docs:
 	./docs/build.sh

--- a/docs/root/install.md
+++ b/docs/root/install.md
@@ -3,7 +3,7 @@
 
 If you just want to checkout Confidant and aren't looking to deploy it into
 production, it's possible to get started without any external dependencies.
-Check out the [test and development quickstart](../../advanced/contributing/#quickstart-for-testing-or-development)
+Check out the [test and development quickstart](contributing.html#development-guide)
 for this.
 
 Note that you should _never_ run with this quickstart configuration in production.

--- a/docs/root/upgrade.md
+++ b/docs/root/upgrade.md
@@ -38,7 +38,7 @@ to enable when upgrading to 2.0.0. Putting Confidant into maintenance mode
 will disallow any writes via the API, ensuring that blind credentials with the
 new data format aren't written until you've run the maintenance script. This
 is useful to allow you to downgrade to an older version, if necessary. See the
-[maintenance mode settings docs](https://lyft.github.io/confidant/basics/configuration/#maintenance-mode-settings)
+[maintenance mode settings docs](configuration.html#maintenance-mode-settings)
 for how to enable maintenance mode.
 
 ## Upgrading to 4.0.0


### PR DESCRIPTION
When we switched from middleman to sphinx, we forgot to fix some inter-doc links. This change updates the links to point to the rendered html files as relative links.