### PR TITLE
Don't force people to register bootstrapped secrets

### DIFF
--- a/confidant/encrypted_settings.py
+++ b/confidant/encrypted_settings.py
@@ -35,7 +35,7 @@ class EncryptedSettings(object):
     def get_secret(self, name):
         if self.decrypted_secrets is None:
             self.decrypted_secrets = self._bootstrap(self.secret_string)
-        return self.decrypted_secrets.get(name, self.secret_defaults[name])
+        return self.decrypted_secrets.get(name, self.secret_defaults.get(name))
 
     def get_all_secrets(self):
         secrets = {}

--- a/confidant/scripts/bootstrap.py
+++ b/confidant/scripts/bootstrap.py
@@ -15,7 +15,12 @@ from confidant.lib import cryptolib
 class GenerateSecretsBootstrap(Command):
 
     option_list = [
-        Option('--in', dest='_in', default='-'),
+        Option(
+            '--in',
+            dest='_in',
+            default='-',
+            help='Path to YAML file containing all the secrets',
+        ),
         Option('--out', dest='_out', default='-')
     ]
 


### PR DESCRIPTION
By changing `dict[key]` to `dict.get('key')`, people no longer need to register the optional parameter when bootstrapping secrets

I was confused whether I needed a JSON or YAML file when bootstrapping so adding a bit of extra documentation there