### PR TITLE
Add tags to the edit/new credential UI

### DIFF
--- a/confidant/public/modules/resources/controllers/CredentialDetailsCtrl.js
+++ b/confidant/public/modules/resources/controllers/CredentialDetailsCtrl.js
@@ -257,7 +257,12 @@
                         $scope.credential.mungedTags.splice(i, 1);
                         continue;
                     }
+                    // strip duplicates
                     if (tagItem.id in _credential.tags) {
+                        continue;
+                    }
+                    // strip empty tag selection
+                    if (tagItem.id === '') {
                         continue;
                     }
                     _credential.tags.push(tagItem.id);

--- a/confidant/public/modules/resources/controllers/CredentialDetailsCtrl.js
+++ b/confidant/public/modules/resources/controllers/CredentialDetailsCtrl.js
@@ -50,12 +50,14 @@
             $scope.credentialPairConflicts = null;
             $scope.hasMetadata = false;
             $scope.permissions = $scope.clientconfig.generated.permissions;
+            $scope.definedTags = $scope.clientconfig.generated.defined_tags;
             $scope.credentialId = $stateParams.credentialId;
             $scope.showCredentials = false;
 
             function populateCredential(credential) {
                 var _credentialPairs = [],
-                    _metadata = [];
+                    _metadata = [],
+                    _tags = [];
                 if (!angular.equals({}, credential.credential_pairs)) {
                     angular.forEach(credential.credential_pairs, function(value, key) {
                         this.push({'key': key, 'value': value});
@@ -68,8 +70,12 @@
                 angular.forEach(credential.metadata, function(value, key) {
                     this.push({'key': key, 'value': value});
                 }, _metadata);
+                angular.forEach(credential.tags, function(value) {
+                    this.push({'id': value});
+                }, _tags);
                 credential.credentialPairs = _credentialPairs;
                 credential.mungedMetadata = _metadata;
+                credential.mungedTags = _tags;
                 $scope.credential = credential;
                 credentialCopy = angular.copy($scope.credential);
             }
@@ -97,7 +103,8 @@
                     name: '',
                     enabled: true,
                     credentialPairs: [{'key': '', 'value': ''}],
-                    mungedMetadata: []
+                    mungedMetadata: [],
+                    mungedTags: []
                 };
                 credentialCopy = angular.copy($scope.credential);
                 $scope.shown = true;
@@ -128,6 +135,10 @@
                 return metadataItem.isDeleted !== true;
             };
 
+            $scope.filterTags = function(tagItem) {
+                return tagItem.isDeleted !== true;
+            };
+
             $scope.getCredentialByID = function(id) {
                 return $filter('filter')($scope.$parent.credentialList, {'id': id})[0];
             };
@@ -146,8 +157,7 @@
             $scope.addCredentialPair = function() {
                 $scope.credential.credentialPairs.push({
                     key: '',
-                    value: '',
-                    isNew: true
+                    value: ''
                 });
             };
 
@@ -161,8 +171,20 @@
             $scope.addMetadata = function() {
                 $scope.credential.mungedMetadata.push({
                     key: '',
-                    value: '',
-                    isNew: true
+                    value: ''
+                });
+            };
+
+            $scope.deleteTag = function($$hashKey) {
+                var filtered = $filter('filter')($scope.credential.mungedTags, {'$$hashKey': $$hashKey});
+                if (filtered.length) {
+                    filtered[0].isDeleted = true;
+                }
+            };
+
+            $scope.addTag = function() {
+                $scope.credential.mungedTags.push({
+                    id: '',
                 });
             };
 
@@ -199,6 +221,7 @@
                 _credential.documentation = $scope.credential.documentation;
                 _credential.credential_pairs = {};
                 _credential.metadata = {};
+                _credential.tags = [];
                 $scope.saveError = '';
                 // Ensure credential pair keys are unique and transform them
                 // into key/value dict.
@@ -228,6 +251,17 @@
                     }
                     _credential.metadata[metadataItem.key] = metadataItem.value;
                 }
+                for (i = $scope.credential.mungedTags.length; i--;) {
+                    var tagItem = $scope.credential.mungedTags[i];
+                    if (tagItem.isDeleted) {
+                        $scope.credential.mungedTags.splice(i, 1);
+                        continue;
+                    }
+                    if (tagItem.id in _credential.tags) {
+                        continue;
+                    }
+                    _credential.tags.push(tagItem.id);
+                }
                 if (angular.equals(credentialCopy, $scope.credential)) {
                     $scope.saveError = 'No changes made.';
                     deferred.reject();
@@ -236,17 +270,7 @@
                 // Update an existing credential.
                 if ($scope.credential.id) {
                     Credential.update({'id': $scope.credential.id}, _credential).$promise.then(function(newCredential) {
-                        var _credentialPairs = [],
-                            _metadata = [];
-                        angular.forEach(newCredential.credential_pairs, function(value, key) {
-                            this.push({'key': key, 'value': value});
-                        }, _credentialPairs);
-                        angular.forEach(newCredential.metadata, function(value, key) {
-                            this.push({'key': key, 'value': value});
-                        }, _metadata);
-                        newCredential.credentialPairs = _credentialPairs;
-                        newCredential.mungedMetadata = _metadata;
-                        $scope.credential = newCredential;
+                        populateCredential(newCredential);
                         if (credentialCopy.name !== $scope.credential.name ||
                             credentialCopy.enabled !== $scope.credential.enabled) {
                             $scope.$emit('updateCredentialList');

--- a/confidant/public/modules/resources/views/credential-details.html
+++ b/confidant/public/modules/resources/views/credential-details.html
@@ -127,6 +127,26 @@
       </span>
     </div>
     <div class="form-group">
+      <label for="tagInputs">Tags</label>
+      <div class="well">
+        <div ng-repeat="tag in credential.mungedTags | filter:filterTags" class="row">
+          <div class="col-md-8">
+            <span editable-select="tag.id" e-ng-selected="tag.id == t" e-name="{{ tag.id }}SelectMenu" e-ng-options="t for t in definedTags">
+              {{ tag.id }}
+            </span>
+          </div>
+          <div class="col-md-4" style="padding-bottom: 10px">
+            <button type="button" ng-click="deleteTag(tag.$$hashKey)" class="btn btn-loud" ng-show="editableForm.$visible">Del</button>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="row">
+      <span ng-show="editableForm.$visible">
+        <button type="button" ng-disabled="editableForm.$waiting" ng-click="addTag()" class="btn pull-right">Add Tag</button>
+      </span>
+    </div>
+    <div class="form-group">
       <label for="credentialDocumentationInput">Credential Rotation Documentation</label>
       <span editable-textarea="credential.documentation"
         id="credentialDocumentationInput"

--- a/confidant/routes/identity.py
+++ b/confidant/routes/identity.py
@@ -121,7 +121,9 @@ def get_client_config():
             ),
         },
     }
-    # TODO: add more config in here.
+    tags = set()
+    tags.update(settings.TAGS_EXCLUDING_ROTATION)
+    tags.update(settings.ROTATION_DAYS_CONFIG.keys())
     response = jsonify({
         'defined': settings.CLIENT_CONFIG,
         'generated': {
@@ -130,6 +132,7 @@ def get_client_config():
             'xsrf_cookie_name': settings.XSRF_COOKIE_NAME,
             'maintenance_mode': settings.MAINTENANCE_MODE,
             'history_page_limit': settings.HISTORY_PAGE_LIMIT,
+            'defined_tags': list(tags),
             'permissions': permissions,
         }
     })

--- a/tests/unit/confidant/routes/identity_test.py
+++ b/tests/unit/confidant/routes/identity_test.py
@@ -59,6 +59,7 @@ def test_get_client_config(mocker):
             'xsrf_cookie_name': 'CSRF_TOKEN',
             'maintenance_mode': True,
             'history_page_limit': 50,
+            'defined_tags': [],
             'permissions': {
                 'credentials': {
                     'list': True,


### PR DESCRIPTION
This change adds tags to the edit and new credential UI. The UI currently only allows selection of server defined tags, and specifically only ones defined by the credential rotation settings. Future iterations should allow more server defined tags, or allow user input that isn't from a server defined list.