### PR TITLE
Minor bugfix to prevent duplicate tags

### DIFF
--- a/confidant/public/modules/resources/controllers/CredentialDetailsCtrl.js
+++ b/confidant/public/modules/resources/controllers/CredentialDetailsCtrl.js
@@ -258,7 +258,7 @@
                         continue;
                     }
                     // strip duplicates
-                    if (tagItem.id in _credential.tags) {
+                    if (_credential.tags.includes(tagItem.id)) {
                         continue;
                     }
                     // strip empty tag selection


### PR DESCRIPTION
```
"a" in ["a", "b", "c"]
false

0 in ["a", "b", "c"]
true

3 in ["a", "b", "c"]
false

"a" in {"a": "z"}
true

["a"].includes("a")
true
```

js is nuts to me.