### PR TITLE
Fix timezone comparison issue

### DIFF
--- a/confidant/routes/credentials.py
+++ b/confidant/routes/credentials.py
@@ -4,7 +4,6 @@ import logging
 import re
 import uuid
 
-from datetime import datetime
 from flask import blueprints, jsonify, request
 from pynamodb.exceptions import DoesNotExist, PutError
 
@@ -206,7 +205,7 @@ def get_credential(id):
                 logger.error('Archived credential {}-{} not found'.format(
                         id, credential.revision)
                 )
-            now = datetime.now()
+            now = misc.utcnow()
             credential.last_decrypted_date = now
             credential.save()
             if archived_credential:
@@ -596,7 +595,7 @@ def create_credential():
     data_key = keymanager.create_datakey(encryption_context={'id': id})
     cipher = CipherManager(data_key['plaintext'], version=2)
     credential_pairs = cipher.encrypt(credential_pairs)
-    last_rotation_date = datetime.now()
+    last_rotation_date = misc.utcnow()
     cred = Credential(
         id='{0}-{1}'.format(id, revision),
         data_type='archive-credential',
@@ -827,7 +826,7 @@ def update_credential(id):
         # decrypted credential pair of the most recent revision, assume that
         # this is a new credential pair and update last_rotation_date
         if credential_pairs != _cred.decrypted_credential_pairs:
-            update['last_rotation_date'] = datetime.now()
+            update['last_rotation_date'] = misc.utcnow()
         data_key = keymanager.create_datakey(encryption_context={'id': id})
         cipher = CipherManager(data_key['plaintext'], version=2)
         update['credential_pairs'] = cipher.encrypt(

--- a/confidant/utils/misc.py
+++ b/confidant/utils/misc.py
@@ -1,4 +1,6 @@
 import importlib
+import pytz
+from datetime import datetime
 
 
 def dict_deep_update(a, b):
@@ -43,3 +45,12 @@ def get_boolean(val, default=False):
     if val is None:
         return default
     return val in ['True', 'true', '1']
+
+
+def utcnow():
+    """
+    Returns the current time with tzinfo='UTC'.
+    datetime.utcnow() currently does not populate tzinfo
+    """
+    now = datetime.utcnow()
+    return now.replace(tzinfo=pytz.utc)

--- a/requirements.in
+++ b/requirements.in
@@ -187,3 +187,6 @@ pytest-env==0.6.2
 # License: MIT
 # Upstream url: https://github.com/asottile/pytest-gevent
 pytest-gevent==1.0.0
+
+# Timezones
+pytz

--- a/requirements.txt
+++ b/requirements.txt
@@ -66,6 +66,7 @@ pytest==4.6.9
 python-dateutil==2.8.0    # via botocore, pynamodb
 python-json-logger==0.1.11
 python3-saml==1.9.0
+pytz==2019.1
 pyyaml==5.1.2
 redis==2.10.3
 requests==2.22.0

--- a/requirements3.txt
+++ b/requirements3.txt
@@ -57,6 +57,7 @@ pytest==4.6.9
 python-dateutil==2.8.0    # via botocore, pynamodb
 python-json-logger==0.1.11
 python3-saml==1.9.0
+pytz==2019.1
 pyyaml==5.1.2
 redis==2.10.3
 requests==2.22.0


### PR DESCRIPTION
When `ENABLE_SAVE_LAST_DECRYPTION_TIME` is enabled and the eye icon is clicked, confidant returns a 5xx because the `last_rotation_date` field of the response is trying to compare a tz unaware timestamp with a tz aware timestamp.  Essentially what was happening was:

```
# Assume someone just rotated a credential
c = Credential.get(123)
c.last_rotation_date = datetime.now() # no tzinfo
c.save()   # Pynamo will add tzinfo=UTC to last_rotation_date
...
# One day later
...
c = Credential.get(123)
c.last_decrypted_date = datetime.now() # no tzinfo
c.save()  # Pynamo will add tzinfo=UTC to last_decrypted_date
c.next_rotation_date # uses the unsaved object (`c`) and compares `last_decrypted_date` (no tzinfo with last_rotation_date, which has the tzinfo because pynamo added it
```

Essentially, had we refetched the object (did another `Credential.get(123)`), we wouldn't have this problem but we were using the unsaved object.

Instead of using datetime.now() we create a new method that automatically adds a tzinfo.

(Side note: Why python's datetime.utcnow() doesn't have a tzinfo in it is beyond me)