### PR TITLE
mapping .:/srv/confidant seems like debugging leftover

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,7 +42,6 @@ services:
       - saml-idp
     env_file: ./config/development/confidant.env
     volumes:
-      - .:/srv/confidant
       - ./config/development/logging.conf:/etc/confidant/logging.conf
       - ./config/development/idp.crt:/etc/confidant/idp.crt
       - ./config/gunicorn.conf:/etc/confidant/gunicorn.conf


### PR DESCRIPTION
alternatively, `make up` is incorrect and needs to run npm and grunt to
ensure the javascript/css is available