### PR TITLE
Add access control to credentials based on group membership

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,8 @@ pip-log.txt
 .tox
 nosetests.xml
 karma-test-results.xml
+coverage.xml
+package-lock.json
 
 # Translations
 *.mo

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /srv/confidant
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         curl ca-certificates \
-    && /usr/bin/curl -sL --fail https://deb.nodesource.com/setup_8.x | bash -
+    && /usr/bin/curl -sL --fail https://deb.nodesource.com/setup_12.x | bash -
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         # For frontend
@@ -32,9 +32,9 @@ RUN virtualenv /venv -ppython3 && \
 COPY .jshintrc Gruntfile.js /srv/confidant/
 COPY confidant/public /srv/confidant/confidant/public
 
-RUN node_modules/grunt-cli/bin/grunt build
-
 COPY . /srv/confidant
+
+RUN node_modules/grunt-cli/bin/grunt build
 
 EXPOSE 80
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,4 +33,9 @@ COPY . /srv/confidant
 
 EXPOSE 80
 
+# added this to test the saml stuff
+RUN groupadd confidantTestGroup
+RUN useradd confidant-user
+RUN usermod -a -G confidantTestGroup confidant-user
+
 CMD ["gunicorn", "confidant.wsgi:app", "--workers=2", "-k", "gevent", "--access-logfile=-", "--error-logfile=-"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,9 +19,6 @@ RUN apt-get update \
 
 COPY package.json /srv/confidant/
 
-RUN npm install grunt-cli && \
-    npm install
-
 COPY piptools_requirements*.txt requirements*.txt /srv/confidant/
 
 ENV PATH=/venv/bin:$PATH
@@ -33,8 +30,6 @@ COPY .jshintrc Gruntfile.js /srv/confidant/
 COPY confidant/public /srv/confidant/confidant/public
 
 COPY . /srv/confidant
-
-RUN node_modules/grunt-cli/bin/grunt build
 
 EXPOSE 80
 

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ down:
 docker_build: clean
 	npm install grunt-cli && npm install
 	node_modules/grunt-cli/bin/grunt build
-	docker build -t lyft/confidant . --no-cache
+	docker build -t lyft/confidant .
 
 docker_test: docker_build docker_test_unit docker_test_integration docker_test_frontend down
 

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,9 @@ test_unit: clean
 	pytest --strict --junitxml=build/unit.xml --cov=confidant --cov-report=html --cov-report=xml --cov-report=term --no-cov-on-fail tests/unit
 
 test_frontend:
-	node_modules/grunt-cli/bin/grunt test
+	npm install grunt-cli && npm install
+	node_modules/grunt-cli/bin/grunt build
+	./node_modules/grunt-cli/bin/grunt test
 
 .PHONY: compile_deps # freeze requirements.in to requirements3.txt
 compile_deps:

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,8 @@ down:
 	docker-compose down
 
 docker_build: clean
+	npm install grunt-cli && npm install
+	node_modules/grunt-cli/bin/grunt build
 	docker build -t lyft/confidant .
 
 docker_test: docker_build docker_test_unit docker_test_integration docker_test_frontend down
@@ -42,8 +44,6 @@ test_unit: clean
 	pytest --strict --junitxml=build/unit.xml --cov=confidant --cov-report=html --cov-report=xml --cov-report=term --no-cov-on-fail tests/unit
 
 test_frontend:
-	npm install grunt-cli && npm install
-	node_modules/grunt-cli/bin/grunt build
 	./node_modules/grunt-cli/bin/grunt test
 
 .PHONY: compile_deps # freeze requirements.in to requirements3.txt

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ down:
 docker_build: clean
 	npm install grunt-cli && npm install
 	node_modules/grunt-cli/bin/grunt build
-	docker build -t lyft/confidant .
+	docker build -t lyft/confidant . --no-cache
 
 docker_test: docker_build docker_test_unit docker_test_integration docker_test_frontend down
 

--- a/confidant/authnz/__init__.py
+++ b/confidant/authnz/__init__.py
@@ -15,11 +15,12 @@ from confidant.authnz.errors import (
 )
 from confidant.authnz import userauth
 
+import grp
+
 _VALIDATOR = None
 
 logger = logging.getLogger(__name__)
 user_mod = userauth.init_user_auth_class()
-
 
 def _get_validator():
     global _VALIDATOR
@@ -58,7 +59,6 @@ def user_is_user_type(user_type):
         return True
     return False
 
-
 def user_is_service(service):
     if not settings.USE_AUTH:
         return True
@@ -66,6 +66,13 @@ def user_is_service(service):
         return True
     return False
 
+def user_in_group(groupname):
+    try:
+        group = grp.getgrnam(groupname)
+    except KeyError:
+        return False
+    user = get_logged_in_user()
+    return user in group[3]
 
 def service_in_account(account):
     # We only scope to account, if an account is specified.

--- a/confidant/authnz/__init__.py
+++ b/confidant/authnz/__init__.py
@@ -66,12 +66,16 @@ def user_is_service(service):
         return True
     return False
 
+# TODO: ASK STRIPE ABOUT THIS!
+# IF GET_LOGGED_IN_USER IS AN EMAIL, WE CHECK THE GROUP MEMBERSHIP OF THE EMAIL PREFIX!
 def user_in_group(groupname):
     try:
         group = grp.getgrnam(groupname)
     except KeyError:
         return False
     user = get_logged_in_user()
+    if '@' in user:
+        user = user.split('@')[0]
     return user in group[3]
 
 def service_in_account(account):

--- a/confidant/authnz/__init__.py
+++ b/confidant/authnz/__init__.py
@@ -68,15 +68,18 @@ def user_is_service(service):
 
 # TODO: ASK STRIPE ABOUT THIS!
 # IF GET_LOGGED_IN_USER IS AN EMAIL, WE CHECK THE GROUP MEMBERSHIP OF THE EMAIL PREFIX!
-def user_in_group(groupname):
-    try:
-        group = grp.getgrnam(groupname)
-    except KeyError:
-        return False
-    user = get_logged_in_user()
-    if '@' in user:
-        user = user.split('@')[0]
-    return user in group[3]
+def user_in_groups(groupnames):
+    for groupname in groupnames:
+        try:
+            group = grp.getgrnam(groupname)
+        except KeyError:
+            continue
+        user = get_logged_in_user()
+        if '@' in user:
+            user = user.split('@')[0]
+        if user in group[3]:
+            return True
+    return False
 
 def service_in_account(account):
     # We only scope to account, if an account is specified.

--- a/confidant/authnz/errors.py
+++ b/confidant/authnz/errors.py
@@ -1,6 +1,5 @@
 # authentication / authorization related error classes
 
-
 class UserUnknownError(Exception):
     pass
 

--- a/confidant/authnz/rbac.py
+++ b/confidant/authnz/rbac.py
@@ -2,7 +2,7 @@ import re
 
 from confidant import authnz
 from confidant.services import certificatemanager
-
+from confidant.models.credential import Credential
 
 def default_acl(*args, **kwargs):
     """ Default ACLs for confidant: Allow access to all resource types
@@ -25,6 +25,13 @@ def default_acl(*args, **kwargs):
     action = kwargs.get('action')
     resource_id = kwargs.get('resource_id')
     resource_kwargs = kwargs.get('kwargs')
+    if resource_type == 'credential' and resource_id is not None:
+        try:
+            cred = Credential.get(resource_id)
+        except:
+            return False
+        if cred.group is not None and not authnz.user_in_group(cred.group):
+            return False
     if authnz.user_is_user_type('user'):
         if resource_type == 'certificate':
             return False

--- a/confidant/authnz/rbac.py
+++ b/confidant/authnz/rbac.py
@@ -30,7 +30,9 @@ def default_acl(*args, **kwargs):
             cred = Credential.get(resource_id)
         except:
             return False
-        if cred.group is not None and not authnz.user_in_group(cred.group):
+        if len(cred.groups) and not authnz.user_in_groups(cred.groups):
+            if 'error_message_handler' in kwargs:
+                kwargs['error_message_handler']("Not a member of any of the following groups: {}".format(cred.groups))
             return False
     if authnz.user_is_user_type('user'):
         if resource_type == 'certificate':
@@ -69,7 +71,6 @@ def default_acl(*args, **kwargs):
     else:
         # This should never happen, but paranoia wins out
         return False
-
 
 def no_acl(*args, **kwargs):
     """ Stub function that always returns true

--- a/confidant/models/blind_credential.py
+++ b/confidant/models/blind_credential.py
@@ -51,6 +51,7 @@ class BlindCredential(Model):
     modified_date = UTCDateTimeAttribute(default=datetime.now)
     modified_by = UnicodeAttribute()
     documentation = UnicodeAttribute(null=True)
+    group = UnicodeAttribute(null=True)
 
     def equals(self, other_cred):
         if self.name != other_cred.name:
@@ -70,5 +71,7 @@ class BlindCredential(Model):
         if self.metadata != other_cred.metadata:
             return False
         if self.documentation != other_cred.documentation:
+            return False
+        if self.group != other_cred.group:
             return False
         return True

--- a/confidant/models/blind_credential.py
+++ b/confidant/models/blind_credential.py
@@ -6,7 +6,8 @@ from pynamodb.attributes import (
     NumberAttribute,
     BooleanAttribute,
     UTCDateTimeAttribute,
-    JSONAttribute
+    JSONAttribute,
+    ListAttribute
 )
 from pynamodb.indexes import GlobalSecondaryIndex, AllProjection
 
@@ -51,7 +52,7 @@ class BlindCredential(Model):
     modified_date = UTCDateTimeAttribute(default=datetime.now)
     modified_by = UnicodeAttribute()
     documentation = UnicodeAttribute(null=True)
-    group = UnicodeAttribute(null=True)
+    groups = ListAttribute(default=list)
 
     def equals(self, other_cred):
         if self.name != other_cred.name:
@@ -72,6 +73,6 @@ class BlindCredential(Model):
             return False
         if self.documentation != other_cred.documentation:
             return False
-        if self.group != other_cred.group:
+        if set(self.groups) != set(other_cred.groups):
             return False
         return True

--- a/confidant/models/credential.py
+++ b/confidant/models/credential.py
@@ -56,6 +56,8 @@ class CredentialBase(Model):
     tags = ListAttribute(default=list)
     last_decrypted_date = UTCDateTimeAttribute(null=True)
     last_rotation_date = UTCDateTimeAttribute(null=True)
+    # if a user is not in the group, cannot interact w credential
+    group = UnicodeAttribute(null=True)
 
 
 class Credential(CredentialBase):
@@ -81,6 +83,8 @@ class Credential(CredentialBase):
         if self.documentation != other_cred.documentation:
             return False
         if set(self.tags) != set(other_cred.tags):
+            return False
+        if self.group != other_cred.group:
             return False
         return True
 
@@ -131,6 +135,8 @@ class Credential(CredentialBase):
             'added': new.modified_date,
             'removed': old.modified_date,
         }
+        if old.group != new.group:
+            diff['group'] = {'added': new.group, 'removed': old.group}
         return diff
 
     def _diff_dict(self, old, new):
@@ -228,6 +234,7 @@ class Credential(CredentialBase):
             tags=archive_credential.tags,
             last_decrypted_date=archive_credential.last_decrypted_date,
             last_rotation_date=archive_credential.last_rotation_date,
+            group=archive_credential.group,
         )
 
 
@@ -261,4 +268,5 @@ class CredentialArchive(CredentialBase):
             tags=credential.tags,
             last_decrypted_date=credential.last_decrypted_date,
             last_rotation_date=credential.last_rotation_date,
+            group=credential.group,
         )

--- a/confidant/models/credential.py
+++ b/confidant/models/credential.py
@@ -56,8 +56,8 @@ class CredentialBase(Model):
     tags = ListAttribute(default=list)
     last_decrypted_date = UTCDateTimeAttribute(null=True)
     last_rotation_date = UTCDateTimeAttribute(null=True)
-    # if a user is not in the group, cannot interact w credential
-    group = UnicodeAttribute(null=True)
+    # if a user is not in one of the groups, cannot interact w credential
+    groups = ListAttribute(default=list)
 
 
 class Credential(CredentialBase):
@@ -84,7 +84,7 @@ class Credential(CredentialBase):
             return False
         if set(self.tags) != set(other_cred.tags):
             return False
-        if self.group != other_cred.group:
+        if set(self.groups) != set(other_cred.groups):
             return False
         return True
 
@@ -135,8 +135,11 @@ class Credential(CredentialBase):
             'added': new.modified_date,
             'removed': old.modified_date,
         }
-        if old.group != new.group:
-            diff['group'] = {'added': new.group, 'removed': old.group}
+        if set(old.groups) != set(new.groups):
+            diff['groups'] = {
+                'added': list(set(new.groups) - set(old.groups)),
+                'removed': list(set(old.groups) - set(new.groups)),
+            }
         return diff
 
     def _diff_dict(self, old, new):
@@ -234,7 +237,7 @@ class Credential(CredentialBase):
             tags=archive_credential.tags,
             last_decrypted_date=archive_credential.last_decrypted_date,
             last_rotation_date=archive_credential.last_rotation_date,
-            group=archive_credential.group,
+            groups=archive_credential.groups,
         )
 
 
@@ -268,5 +271,5 @@ class CredentialArchive(CredentialBase):
             tags=credential.tags,
             last_decrypted_date=credential.last_decrypted_date,
             last_rotation_date=credential.last_rotation_date,
-            group=credential.group,
+            groups=credential.groups,
         )

--- a/confidant/public/modules/resources/controllers/CredentialDetailsCtrl.js
+++ b/confidant/public/modules/resources/controllers/CredentialDetailsCtrl.js
@@ -260,7 +260,7 @@
                         continue;
                     }
                     // strip duplicates
-                    if (tagItem.id in _credential.tags) {
+                    if (_credential.tags.includes(tagItem.id)) {
                         continue;
                     }
                     // strip empty tag selection

--- a/confidant/public/modules/resources/controllers/CredentialDetailsCtrl.js
+++ b/confidant/public/modules/resources/controllers/CredentialDetailsCtrl.js
@@ -113,7 +113,7 @@
                     credentialPairs: [{'key': '', 'value': ''}],
                     mungedMetadata: [],
                     mungedTags: [],
-                    group: '',
+                    groups: [],
                 };
                 credentialCopy = angular.copy($scope.credential);
                 $scope.shown = true;
@@ -228,7 +228,7 @@
                 _credential.name = $scope.credential.name;
                 _credential.enabled = $scope.credential.enabled;
                 _credential.documentation = $scope.credential.documentation;
-                _credential.group = $scope.credential.group;
+                _credential.groups = [];
                 _credential.credential_pairs = {};
                 _credential.metadata = {};
                 _credential.tags = [];
@@ -260,6 +260,14 @@
                         return $scope.saveError;
                     }
                     _credential.metadata[metadataItem.key] = metadataItem.value;
+                }
+                // Remove whitespace from group names
+                var unmungedGroups = $scope.credential.groups.split(",");
+                for (i = 0; i < unmungedGroups.length; i++) {
+                    var grp = unmungedGroups[i].trim();
+                    if (grp.length > 0) {
+                        _credential.groups.push(grp);
+                    }
                 }
                 for (i = $scope.credential.mungedTags.length; i--;) {
                     var tagItem = $scope.credential.mungedTags[i];

--- a/confidant/public/modules/resources/controllers/CredentialDetailsCtrl.js
+++ b/confidant/public/modules/resources/controllers/CredentialDetailsCtrl.js
@@ -106,7 +106,8 @@
                     enabled: true,
                     credentialPairs: [{'key': '', 'value': ''}],
                     mungedMetadata: [],
-                    mungedTags: []
+                    mungedTags: [],
+                    group: "",
                 };
                 credentialCopy = angular.copy($scope.credential);
                 $scope.shown = true;
@@ -221,6 +222,7 @@
                 _credential.name = $scope.credential.name;
                 _credential.enabled = $scope.credential.enabled;
                 _credential.documentation = $scope.credential.documentation;
+                _credential.group = $scope.credential.group;
                 _credential.credential_pairs = {};
                 _credential.metadata = {};
                 _credential.tags = [];

--- a/confidant/public/modules/resources/controllers/CredentialDetailsCtrl.js
+++ b/confidant/public/modules/resources/controllers/CredentialDetailsCtrl.js
@@ -262,7 +262,7 @@
                     _credential.metadata[metadataItem.key] = metadataItem.value;
                 }
                 // Remove whitespace from group names
-                var unmungedGroups = $scope.credential.groups.split(",");
+                var unmungedGroups = $scope.credential.groups.split(',');
                 for (i = 0; i < unmungedGroups.length; i++) {
                     var grp = unmungedGroups[i].trim();
                     if (grp.length > 0) {

--- a/confidant/public/modules/resources/views/credential-details.html
+++ b/confidant/public/modules/resources/views/credential-details.html
@@ -176,6 +176,10 @@
       <span id="credentialRevision">{{ credential.revision }} (<a href="#/history/credentials/{{ credential.id }}-{{ credential.revision }}">view history</a>)</span>
     </div>
     <div class="form-group" ng-show="credential.id">
+      <label for="credentialGroup">Credential Group (users outside this group cannot view or modify the credential)</label>
+      <span id="credentialGroup">{{ credential.group }}</span>
+    </div>
+    <div class="form-group" ng-show="credential.id">
       <label for="credentialServices">Services Using This Credential</label>
           <div class="well well-sm">
               <ul id="credentialServices" class="list-unstyled">

--- a/confidant/public/modules/resources/views/credential-details.html
+++ b/confidant/public/modules/resources/views/credential-details.html
@@ -94,8 +94,8 @@
       </span>
     </div>
     <div class="form-group">
-      <label for="credentialGroupInput">Credential Group</label>
-      <span editable-text="credential.group" id="credentialGroupInput" style="color:#333333">{{ credential.group || 'Not set' }}</span>
+      <label for="credentialGroupListInput">Credential Groups</label>
+      <span editable-text="credential.groups" id="credentialGroupListInput" style="color:#333333">{{ credential.groups.join(",") || 'Not set' }}</span>
     </div>
     <div class="form-group">
       <label for="credentialMetadata">Credential Metadata</label>

--- a/confidant/public/modules/resources/views/credential-details.html
+++ b/confidant/public/modules/resources/views/credential-details.html
@@ -180,10 +180,6 @@
       <span id="credentialRevision">{{ credential.revision }} (<a href="#/history/credentials/{{ credential.id }}-{{ credential.revision }}">view history</a>)</span>
     </div>
     <div class="form-group" ng-show="credential.id">
-      <label for="credentialGroup">Credential Group (users outside this group cannot view or modify the credential)</label>
-      <span id="credentialGroup">{{ credential.group }}</span>
-    </div>
-    <div class="form-group" ng-show="credential.id">
       <label for="credentialServices">Services Using This Credential</label>
           <div class="well well-sm">
               <ul id="credentialServices" class="list-unstyled">

--- a/confidant/routes/certificates.py
+++ b/confidant/routes/certificates.py
@@ -248,7 +248,6 @@ def list_cas():
        GET /v1/cas
 
     **Example response**:
-
     .. sourcecode:: http
 
        HTTP/1.1 200 OK
@@ -310,7 +309,6 @@ def get_ca(ca):
     :type ca: str
 
     **Example response**:
-
     .. sourcecode:: http
 
        HTTP/1.1 200 OK

--- a/confidant/routes/credentials.py
+++ b/confidant/routes/credentials.py
@@ -76,7 +76,8 @@ def get_credential_list():
              "documentation": "Example documentation",
              "modified_date": "2019-12-16T23:16:11.413299+00:00",
              "modified_by": "rlane@example.com",
-             "permissions": {}
+             "permissions": {},
+             "group": "security-group"
            },
            ...
          ],
@@ -144,6 +145,7 @@ def get_credential(id):
          "documentation": "Example documentation",
          "modified_date": "2019-12-16T23:16:11.413299+00:00",
          "modified_by": "rlane@example.com",
+         "group": "security-group",
          "permissions": {
            "metadata": true,
            "get": true,
@@ -611,6 +613,7 @@ def create_credential():
         documentation=data.get('documentation'),
         tags=data.get('tags', []),
         last_rotation_date=last_rotation_date,
+        group=data.get('group', None),
     ).save(id__null=True)
     # Make this the current revision
     cred = Credential(
@@ -627,6 +630,7 @@ def create_credential():
         documentation=data.get('documentation'),
         tags=data.get('tags', []),
         last_rotation_date=last_rotation_date,
+        group=data.get('group', None)
     )
     cred.save()
     permissions = {
@@ -783,6 +787,7 @@ def update_credential(id):
         'metadata': data.get('metadata', _cred.metadata),
         'documentation': data.get('documentation', _cred.documentation),
         'tags': data.get('tags', _cred.tags),
+        'group': data.get('group', _cred.group),
     }
     # Enforce documentation, EXCEPT if we are restoring an old revision
     if (not update['documentation'] and
@@ -850,6 +855,7 @@ def update_credential(id):
             documentation=update['documentation'],
             tags=update['tags'],
             last_rotation_date=update['last_rotation_date'],
+            group=update['group'],
         ).save(id__null=True)
     except PutError as e:
         logger.error(e)
@@ -869,6 +875,7 @@ def update_credential(id):
             documentation=update['documentation'],
             tags=update['tags'],
             last_rotation_date=update['last_rotation_date'],
+            group=update['group'],
         )
         cred.save()
     except PutError as e:
@@ -1024,6 +1031,7 @@ def revert_credential_to_revision(id, to_revision):
             documentation=revert_credential.documentation,
             tags=revert_credential.tags,
             last_rotation_date=revert_credential.last_rotation_date,
+            group=revert_credential.group,
         ).save(id__null=True)
     except PutError as e:
         logger.error(e)
@@ -1043,6 +1051,7 @@ def revert_credential_to_revision(id, to_revision):
             documentation=revert_credential.documentation,
             tags=revert_credential.tags,
             last_rotation_date=revert_credential.last_rotation_date,
+            group=revert_credential.group,
         )
         cred.save()
     except PutError as e:

--- a/confidant/schema/credentials.py
+++ b/confidant/schema/credentials.py
@@ -22,6 +22,7 @@ class CredentialResponse(object):
     tags = attr.ib(default=list)
     last_rotation_date = attr.ib(default=None)
     next_rotation_date = attr.ib(default=None)
+    group = attr.ib(default=None)
 
     @classmethod
     def from_credential(
@@ -42,6 +43,7 @@ class CredentialResponse(object):
             tags=credential.tags,
             last_rotation_date=credential.last_rotation_date,
             next_rotation_date=credential.next_rotation_date,
+            group=credential.group,
         )
         if include_credential_keys:
             ret.credential_keys = credential.credential_keys
@@ -70,6 +72,7 @@ class CredentialResponseSchema(AutobuildSchema):
     tags = fields.List(fields.Str())
     last_rotation_date = fields.DateTime()
     next_rotation_date = fields.DateTime()
+    group = fields.Str()
 
 
 @attr.s

--- a/confidant/schema/credentials.py
+++ b/confidant/schema/credentials.py
@@ -22,7 +22,7 @@ class CredentialResponse(object):
     tags = attr.ib(default=list)
     last_rotation_date = attr.ib(default=None)
     next_rotation_date = attr.ib(default=None)
-    group = attr.ib(default=None)
+    groups = attr.ib(default=list)
 
     @classmethod
     def from_credential(
@@ -43,7 +43,7 @@ class CredentialResponse(object):
             tags=credential.tags,
             last_rotation_date=credential.last_rotation_date,
             next_rotation_date=credential.next_rotation_date,
-            group=credential.group,
+            groups=credential.groups,
         )
         if include_credential_keys:
             ret.credential_keys = credential.credential_keys
@@ -72,7 +72,7 @@ class CredentialResponseSchema(AutobuildSchema):
     tags = fields.List(fields.Str())
     last_rotation_date = fields.DateTime()
     next_rotation_date = fields.DateTime()
-    group = fields.Str()
+    groups = fields.List(fields.Str())
 
 
 @attr.s

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,3 +18,5 @@ The output can be found in `generated/docs`.
 2. The docs are published to [docs/confidant](https://github.com/lyft/confidant.github.io/tree/master/docs/confidant)
    in a directory named after every tagged commit in this repo. Thus, on every tagged release there
    are snapped docs.
+
+// CRTODO: add documentation and CHANGELOG for group support

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,5 +18,3 @@ The output can be found in `generated/docs`.
 2. The docs are published to [docs/confidant](https://github.com/lyft/confidant.github.io/tree/master/docs/confidant)
    in a directory named after every tagged commit in this repo. Thus, on every tagged release there
    are snapped docs.
-
-// CRTODO: add documentation and CHANGELOG for group support

--- a/docs/root/acls.md
+++ b/docs/root/acls.md
@@ -1,5 +1,5 @@
 # Access Controls (ACLs)
-
+# CRTODO: add documentation
 ## Design
 
 The design for managing fine-grained ACLs in confidant is relatively simple. Hookpoints are called whenever a resource type will be accessed by an end-user; these hookpoints look like:

--- a/docs/root/acls.md
+++ b/docs/root/acls.md
@@ -1,5 +1,4 @@
 # Access Controls (ACLs)
-# CRTODO: add documentation
 ## Design
 
 The design for managing fine-grained ACLs in confidant is relatively simple. Hookpoints are called whenever a resource type will be accessed by an end-user; these hookpoints look like:

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "angular-xeditable": "~0.1.9",
     "bootstrap": "3.4.1",
     "es5-shim": "~4.1.13",
+    "grunt-cli": "^1.3.2",
     "json3": "~3.3.2",
     "lodash": "~4.17.15",
     "spin.js": "~2.3.2"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,6 @@
 [pytest]
 
-addopts = -p no:warnings --no-print-logs --strict
+addopts = -p no:warnings --no-print-logs --strict -vvv
 env =
     SESSION_SECRET=secret
     DYNAMODB_CREATE_TABLE=False

--- a/tests/unit/confidant/authnz/authnz_test.py
+++ b/tests/unit/confidant/authnz/authnz_test.py
@@ -97,13 +97,13 @@ def test_user_is_service(mocker):
         assert authnz.user_is_service('notconfidant-unitttest') is False
 
 
-def test_user_in_group(mocker):
+def test_user_in_groups(mocker):
     my_group = ('my_group', '', 1337, ['user1'])
     mocker.patch('grp.getgrnam', return_value=my_group)
     mocker.patch('confidant.authnz.get_logged_in_user', return_value='user1')
-    assert authnz.user_in_group('my_group')
+    assert authnz.user_in_groups(['my_group'])
     mocker.patch('confidant.authnz.get_logged_in_user', return_value='user2')
-    assert not authnz.user_in_group('my_group')
+    assert not authnz.user_in_groups(['my_group'])
 
 def test_service_in_account(mocker):
     # If we aren't scoping, this should pass

--- a/tests/unit/confidant/authnz/authnz_test.py
+++ b/tests/unit/confidant/authnz/authnz_test.py
@@ -97,6 +97,14 @@ def test_user_is_service(mocker):
         assert authnz.user_is_service('notconfidant-unitttest') is False
 
 
+def test_user_in_group(mocker):
+    my_group = ('my_group', '', 1337, ['user1'])
+    mocker.patch('grp.getgrnam', return_value=my_group)
+    mocker.patch('confidant.authnz.get_logged_in_user', return_value='user1')
+    assert authnz.user_in_group('my_group')
+    mocker.patch('confidant.authnz.get_logged_in_user', return_value='user2')
+    assert not authnz.user_in_group('my_group')
+
 def test_service_in_account(mocker):
     # If we aren't scoping, this should pass
     assert authnz.service_in_account(None) is True

--- a/tests/unit/confidant/authnz/rbac_test.py
+++ b/tests/unit/confidant/authnz/rbac_test.py
@@ -118,7 +118,7 @@ def test_default_acl(mocker):
         # Test groups
         g_mock.user_type = 'user'
         g_mock.username = 'test-user'
-        mocker.patch('confidant.authnz.user_in_group', lambda _: False)
+        mocker.patch('confidant.authnz.user_in_groups', lambda _: False)
         credential = Credential(
             id='1234',
             revision=1,
@@ -133,14 +133,14 @@ def test_default_acl(mocker):
             modified_by='test@example.com',
             documentation='',
             last_rotation_date=datetime(2020, 1, 1),
-            group='testgroup'
+            groups=['testgroup']
         )
         mocker.patch(
             'confidant.routes.credentials.Credential.get',
             return_value=credential,
         )
         assert rbac.default_acl(resource_type='credential', resource_id='cred', action='get') is False
-        mocker.patch('confidant.authnz.user_in_group', lambda _: True)
+        mocker.patch('confidant.authnz.user_in_groups', lambda _: True)
         assert rbac.default_acl(resource_type='credential', resource_id='cred', action='get') is True
 
 def test_no_acl():

--- a/tests/unit/confidant/models/credential_test.py
+++ b/tests/unit/confidant/models/credential_test.py
@@ -15,7 +15,7 @@ def test_equals(mocker):
         documentation='',
         metadata={},
         tags=['ADMIN_PRIV'],
-        group='testgroup',
+        groups=['testgroup'],
     )
     cred2 = Credential(
         name='test',
@@ -23,7 +23,7 @@ def test_equals(mocker):
         documentation='',
         metadata={},
         tags=['ADMIN_PRIV'],
-        group='testgroup',
+        groups=['testgroup'],
     )
     assert cred1.equals(cred2) is True
 
@@ -82,7 +82,7 @@ def test_not_equals_different_groups(mocker):
         documentation='',
         metadata={},
         tags=['ADMIN_PRIV'],
-        group='g1',
+        groups=['g1'],
     )
     cred2 = Credential(
         name='test',
@@ -90,7 +90,7 @@ def test_not_equals_different_groups(mocker):
         documentation='',
         metadata={},
         tags=['ADMIN_PRIV'],
-        group='g2',
+        groups=['g2'],
     )
     assert cred1.equals(cred2) is False
 
@@ -112,7 +112,7 @@ def test_diff(mocker):
         modified_by=modified_by,
         modified_date=modified_date_old,
         tags=['FINANCIALLY_SENSITIVE', 'IMPORTANT'],
-        group='g1',
+        groups=['g1'],
     )
     new = Credential(
         name='test2',
@@ -123,7 +123,7 @@ def test_diff(mocker):
         modified_by=modified_by,
         modified_date=modified_date_new,
         tags=['ADMIN_PRIV', 'IMPORTANT'],
-        group='g2',
+        groups=['g2'],
     )
     # TODO: figure out how to test decrypted_credential_pairs. Mocking
     # it is turning out to be difficult.
@@ -152,9 +152,9 @@ def test_diff(mocker):
             'removed': ['FINANCIALLY_SENSITIVE'],
             'added': ['ADMIN_PRIV'],
         },
-        'group': {
-            'removed': 'g1',
-            'added': 'g2',
+        'groups': {
+            'removed': ['g1'],
+            'added': ['g2'],
         },
     }
     assert old.diff(new) == expectedDiff

--- a/tests/unit/confidant/models/credential_test.py
+++ b/tests/unit/confidant/models/credential_test.py
@@ -15,6 +15,7 @@ def test_equals(mocker):
         documentation='',
         metadata={},
         tags=['ADMIN_PRIV'],
+        group='testgroup',
     )
     cred2 = Credential(
         name='test',
@@ -22,6 +23,7 @@ def test_equals(mocker):
         documentation='',
         metadata={},
         tags=['ADMIN_PRIV'],
+        group='testgroup',
     )
     assert cred1.equals(cred2) is True
 
@@ -69,6 +71,29 @@ def test_not_equals_different_tags(mocker):
     assert cred1.equals(cred2) is False
 
 
+def test_not_equals_different_groups(mocker):
+    decrypted_pairs_mock = mocker.patch(
+        'confidant.models.credential.Credential.decrypted_credential_pairs'
+    )
+    decrypted_pairs_mock.return_value = {'test': 'me'}
+    cred1 = Credential(
+        name='test',
+        enabled=True,
+        documentation='',
+        metadata={},
+        tags=['ADMIN_PRIV'],
+        group='g1',
+    )
+    cred2 = Credential(
+        name='test',
+        enabled=True,
+        documentation='',
+        metadata={},
+        tags=['ADMIN_PRIV'],
+        group='g2',
+    )
+    assert cred1.equals(cred2) is False
+
 def test_diff(mocker):
     mocker.patch(
         'confidant.models.credential.Credential'
@@ -87,6 +112,7 @@ def test_diff(mocker):
         modified_by=modified_by,
         modified_date=modified_date_old,
         tags=['FINANCIALLY_SENSITIVE', 'IMPORTANT'],
+        group='g1',
     )
     new = Credential(
         name='test2',
@@ -97,6 +123,7 @@ def test_diff(mocker):
         modified_by=modified_by,
         modified_date=modified_date_new,
         tags=['ADMIN_PRIV', 'IMPORTANT'],
+        group='g2',
     )
     # TODO: figure out how to test decrypted_credential_pairs. Mocking
     # it is turning out to be difficult.
@@ -124,6 +151,10 @@ def test_diff(mocker):
         'tags': {
             'removed': ['FINANCIALLY_SENSITIVE'],
             'added': ['ADMIN_PRIV'],
+        },
+        'group': {
+            'removed': 'g1',
+            'added': 'g2',
         },
     }
     assert old.diff(new) == expectedDiff

--- a/tests/unit/confidant/routes/certificates_test.py
+++ b/tests/unit/confidant/routes/certificates_test.py
@@ -8,6 +8,8 @@ def test_get_certificate(mocker):
     app = create_app()
 
     mocker.patch('confidant.settings.USE_AUTH', False)
+    # making sure that group settings for credentials don't affect certs
+    mocker.patch('confidant.authnz.user_in_group', lambda _: False)
     mocker.patch(
         'confidant.authnz.get_logged_in_user',
         return_value='badservice',

--- a/tests/unit/confidant/routes/certificates_test.py
+++ b/tests/unit/confidant/routes/certificates_test.py
@@ -9,7 +9,7 @@ def test_get_certificate(mocker):
 
     mocker.patch('confidant.settings.USE_AUTH', False)
     # making sure that group settings for credentials don't affect certs
-    mocker.patch('confidant.authnz.user_in_group', lambda _: False)
+    mocker.patch('confidant.authnz.user_in_groups', lambda _: False)
     mocker.patch(
         'confidant.authnz.get_logged_in_user',
         return_value='badservice',

--- a/tests/unit/confidant/routes/credentials_test.py
+++ b/tests/unit/confidant/routes/credentials_test.py
@@ -24,6 +24,7 @@ def credential(mocker):
         modified_by='test@example.com',
         documentation='',
         last_rotation_date=datetime(2020, 1, 1),
+        group='testgroup'
     )
 
 
@@ -43,6 +44,7 @@ def archive_credential(mocker):
         modified_by='test@example.com',
         documentation='',
         tags=['OLD TAG'],
+        group='archivegroup'
     )
 
 
@@ -62,6 +64,7 @@ def credential_list(mocker):
             modified_date=datetime.now(),
             modified_by='test@example.com',
             documentation='',
+            group='g1',
         ),
         Credential(
             id='5678',
@@ -76,6 +79,7 @@ def credential_list(mocker):
             modified_date=datetime.now(),
             modified_by='test@example.com',
             documentation='',
+            group='g2',
         ),
     ]
     return credentials
@@ -294,6 +298,7 @@ def test_diff_credential(mocker, credential):
 
 
 def test_create_credential(mocker, credential):
+    # CRTODO: user can create a credential with a group they are not in
     app = create_app()
     mocker.patch('confidant.settings.USE_AUTH', False)
     mocker.patch(
@@ -381,6 +386,7 @@ def test_create_credential(mocker, credential):
             'credential_pairs': {'key': 'value'},
             'name': 'shiny new key',
             'tags': ['ADMIN_PRIV', 'MY_SPECIAL_TAG'],
+            'group': 'g1'
         }),
     )
     json_data = json.loads(ret.data)

--- a/tests/unit/confidant/routes/credentials_test.py
+++ b/tests/unit/confidant/routes/credentials_test.py
@@ -298,7 +298,6 @@ def test_diff_credential(mocker, credential):
 
 
 def test_create_credential(mocker, credential):
-    # CRTODO: user can create a credential with a group they are not in
     app = create_app()
     mocker.patch('confidant.settings.USE_AUTH', False)
     mocker.patch(

--- a/tests/unit/confidant/routes/credentials_test.py
+++ b/tests/unit/confidant/routes/credentials_test.py
@@ -24,7 +24,7 @@ def credential(mocker):
         modified_by='test@example.com',
         documentation='',
         last_rotation_date=datetime(2020, 1, 1),
-        group='testgroup'
+        groups=['testgroup']
     )
 
 
@@ -44,7 +44,7 @@ def archive_credential(mocker):
         modified_by='test@example.com',
         documentation='',
         tags=['OLD TAG'],
-        group='archivegroup'
+        groups=['archivegroup']
     )
 
 
@@ -64,7 +64,7 @@ def credential_list(mocker):
             modified_date=datetime.now(),
             modified_by='test@example.com',
             documentation='',
-            group='g1',
+            groups=['g1'],
         ),
         Credential(
             id='5678',
@@ -79,7 +79,7 @@ def credential_list(mocker):
             modified_date=datetime.now(),
             modified_by='test@example.com',
             documentation='',
-            group='g2',
+            groups=['g2'],
         ),
     ]
     return credentials
@@ -132,7 +132,7 @@ def test_get_credential(mocker, credential):
     ret = app.test_client().get('/v1/credentials/1234', follow_redirects=False)
     assert ret.status_code == 403
 
-    def acl_module_check(resource_type, action, resource_id):
+    def acl_module_check(resource_type, action, resource_id, **kwargs):
         if action == 'metadata':
             if resource_id == '5678':
                 return False
@@ -385,7 +385,7 @@ def test_create_credential(mocker, credential):
             'credential_pairs': {'key': 'value'},
             'name': 'shiny new key',
             'tags': ['ADMIN_PRIV', 'MY_SPECIAL_TAG'],
-            'group': 'g1'
+            'groups': ['g1']
         }),
     )
     json_data = json.loads(ret.data)

--- a/tests/unit/confidant/routes/identity_test.py
+++ b/tests/unit/confidant/routes/identity_test.py
@@ -1,6 +1,6 @@
 from confidant.authnz import UserUnknownError
 from confidant.app import create_app
-
+from confidant import settings
 
 def test_get_user_info(mocker):
     mocker.patch('confidant.settings.USE_AUTH', False)
@@ -24,7 +24,6 @@ def test_get_user_info_no_user(mocker):
     ret = app.test_client().get('/v1/user/email', follow_redirects=False)
     assert ret.status_code == 200
     assert ret.json == {'email': None}
-
 
 def test_get_client_config(mocker):
     def acl_module_check(resource_type, action):
@@ -59,7 +58,7 @@ def test_get_client_config(mocker):
             'xsrf_cookie_name': 'CSRF_TOKEN',
             'maintenance_mode': True,
             'history_page_limit': 50,
-            'defined_tags': [],
+            'defined_tags': set(['ROTATION_EXCLUDED', 'FINANCIALLY_SENSITIVE']),
             'permissions': {
                 'credentials': {
                     'list': True,
@@ -79,5 +78,7 @@ def test_get_client_config(mocker):
 
     app = create_app()
     ret = app.test_client().get('/v1/client_config', follow_redirects=False)
+    ret_json = dict(ret.json)
+    ret_json['generated']['defined_tags'] = set(ret_json['generated']['defined_tags'])
     assert ret.status_code == 200
     assert ret.json == expected


### PR DESCRIPTION
This PR adds a groups field to credentials. If a user is not in one of the groups associated with a credential then they will be unable to interact with the credential.

This PR picks up from the work in PR #289, updated to the current structure for Confidant, and adds multi group support.