### PR TITLE
Bump pyyaml to 5.3.1

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -115,7 +115,7 @@ guard==1.0.1
 # License: MIT
 # Upstream url: http://pyyaml.org/wiki/PyYAML
 # Use: For parsing users.yaml
-PyYAML==5.1.2
+PyYAML==5.3.1
 
 # License: MIT
 # Upstream url: http://gunicorn.org/

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,77 +4,68 @@
 #
 #    pip-compile --output-file=./requirements.txt ./requirements.in
 #
+
 asn1crypto==0.24.0        # via cryptography
 atomicwrites==1.3.0       # via pytest
 attrs==19.3.0             # via pytest, toastedmarshmallow
-authomatic==1.0.0
-blinker==1.4
-boto3==1.9.227
-botocore==1.12.227
+authomatic==1.0.0         # via -r ./requirements.in
+blinker==1.4              # via -r ./requirements.in
+boto3==1.9.227            # via -r ./requirements.in, kmsauth
+botocore==1.12.227        # via -r ./requirements.in, boto3, pynamodb, s3transfer
 certifi==2019.6.16        # via requests
-cffi==1.12.3
+cffi==1.12.3              # via -r ./requirements.in, cryptography
 chardet==3.0.4            # via requests
 click==7.0                # via flask
-configparser==4.0.2       # via importlib-metadata
-contextlib2==0.6.0.post1  # via importlib-metadata
 coverage==4.5.4           # via pytest-cov
-cryptography==2.7
+cryptography==2.7         # via -r ./requirements.in, pyopenssl
 defusedxml==0.6.0         # via python3-saml
 docutils==0.15.2          # via botocore
-enum34==1.1.6             # via cryptography
-flask-script==2.0.5
-flask-session==0.2.3
-flask-sslify==0.1.5
-flask==1.1.1
-funcsigs==1.0.2           # via mock, pytest
-futures==3.3.0            # via s3transfer
-gevent==1.4.0
-greenlet==0.4.15
-guard==1.0.1
-gunicorn==19.9.0
+flask-script==2.0.5       # via -r ./requirements.in
+flask-session==0.2.3      # via -r ./requirements.in
+flask-sslify==0.1.5       # via -r ./requirements.in
+flask==1.1.1              # via -r ./requirements.in, flask-script, flask-session, flask-sslify
+gevent==1.4.0             # via -r ./requirements.in, pytest-gevent
+greenlet==0.4.15          # via -r ./requirements.in, gevent
+guard==1.0.1              # via -r ./requirements.in
+gunicorn==19.9.0          # via -r ./requirements.in
 idna==2.8                 # via requests
 importlib-metadata==1.3.0  # via pluggy, pytest
-ipaddress==1.0.22         # via cryptography
 isodate==0.6.0            # via python3-saml
 itsdangerous==1.1.0       # via flask
 jinja2==2.10.1            # via flask
 jmespath==0.9.4           # via boto3, botocore
-kmsauth==0.6.0
-lru-dict==1.1.6
+kmsauth==0.6.0            # via -r ./requirements.in
+lru-dict==1.1.6           # via -r ./requirements.in
 lxml==4.4.1               # via xmlsec
 markupsafe==1.1.1         # via jinja2
-mock==2.0.0               # via pytest-mock
-more-itertools==5.0.0     # via pytest, zipp
-ndg-httpsclient==0.5.1
+more-itertools==5.0.0     # via pytest
+ndg-httpsclient==0.5.1    # via -r ./requirements.in
 packaging==20.0           # via pytest
-pathlib2==2.3.5           # via importlib-metadata, pytest
-pbr==5.4.3                # via mock
 pkgconfig==1.5.1          # via xmlsec
 pluggy==0.13.1            # via pytest
 py==1.8.1                 # via pytest
-pyasn1==0.4.6
+pyasn1==0.4.6             # via -r ./requirements.in, ndg-httpsclient
 pycparser==2.19           # via cffi
-pynamodb==3.4.1
-pyopenssl==19.0.0
+pynamodb==3.4.1           # via -r ./requirements.in
+pyopenssl==19.0.0         # via -r ./requirements.in, ndg-httpsclient
 pyparsing==2.4.6          # via packaging
-pytest-cov==2.8.1
-pytest-env==0.6.2
-pytest-gevent==1.0.0
-pytest-lazy-fixture==0.6.1
-pytest-mock==1.11.2
-pytest==4.6.9
+pytest-cov==2.8.1         # via -r ./requirements.in
+pytest-env==0.6.2         # via -r ./requirements.in
+pytest-gevent==1.0.0      # via -r ./requirements.in
+pytest-lazy-fixture==0.6.1  # via -r ./requirements.in
+pytest-mock==1.11.2       # via -r ./requirements.in
+pytest==4.6.9             # via -r ./requirements.in, pytest-cov, pytest-env, pytest-gevent, pytest-lazy-fixture, pytest-mock
 python-dateutil==2.8.0    # via botocore, pynamodb
-python-json-logger==0.1.11
-python3-saml==1.9.0
-pytz==2019.1
-pyyaml==5.1.2
-redis==2.10.3
-requests==2.22.0
+python-json-logger==0.1.11  # via -r ./requirements.in
+python3-saml==1.9.0       # via -r ./requirements.in
+pytz==2019.1              # via -r ./requirements.in
+pyyaml==5.3.1             # via -r ./requirements.in
+redis==2.10.3             # via -r ./requirements.in
+requests==2.22.0          # via -r ./requirements.in
 s3transfer==0.2.1         # via boto3
-scandir==1.10.0           # via pathlib2
-six==1.12.0               # via cryptography, isodate, mock, more-itertools, packaging, pathlib2, pynamodb, pyopenssl, pytest, python-dateutil
-statsd==3.2.1
-toastedmarshmallow==2.15.2.post1
+six==1.12.0               # via cryptography, isodate, more-itertools, packaging, pynamodb, pyopenssl, pytest, python-dateutil
+statsd==3.2.1             # via -r ./requirements.in
+toastedmarshmallow==2.15.2.post1  # via -r ./requirements.in
 urllib3==1.25.3           # via botocore, requests
 wcwidth==0.1.8            # via pytest
 werkzeug==0.15.6          # via flask

--- a/requirements3.txt
+++ b/requirements3.txt
@@ -4,67 +4,68 @@
 #
 #    pip-compile --output-file=./requirements3.txt ./requirements.in
 #
+
 asn1crypto==0.24.0        # via cryptography
 atomicwrites==1.3.0       # via pytest
 attrs==19.3.0             # via pytest, toastedmarshmallow
-authomatic==1.0.0
-blinker==1.4
-boto3==1.9.227
-botocore==1.12.227
+authomatic==1.0.0         # via -r ./requirements.in
+blinker==1.4              # via -r ./requirements.in
+boto3==1.9.227            # via -r ./requirements.in, kmsauth
+botocore==1.12.227        # via -r ./requirements.in, boto3, pynamodb, s3transfer
 certifi==2019.6.16        # via requests
-cffi==1.12.3
+cffi==1.12.3              # via -r ./requirements.in, cryptography
 chardet==3.0.4            # via requests
 click==7.0                # via flask
 coverage==4.5.4           # via pytest-cov
-cryptography==2.7
+cryptography==2.7         # via -r ./requirements.in, pyopenssl
 defusedxml==0.6.0         # via python3-saml
 docutils==0.15.2          # via botocore
-flask-script==2.0.5
-flask-session==0.2.3
-flask-sslify==0.1.5
-flask==1.1.1
-gevent==1.4.0
-greenlet==0.4.15
-guard==1.0.1
-gunicorn==19.9.0
+flask-script==2.0.5       # via -r ./requirements.in
+flask-session==0.2.3      # via -r ./requirements.in
+flask-sslify==0.1.5       # via -r ./requirements.in
+flask==1.1.1              # via -r ./requirements.in, flask-script, flask-session, flask-sslify
+gevent==1.4.0             # via -r ./requirements.in, pytest-gevent
+greenlet==0.4.15          # via -r ./requirements.in, gevent
+guard==1.0.1              # via -r ./requirements.in
+gunicorn==19.9.0          # via -r ./requirements.in
 idna==2.8                 # via requests
 importlib-metadata==1.3.0  # via pluggy, pytest
 isodate==0.6.0            # via python3-saml
 itsdangerous==1.1.0       # via flask
 jinja2==2.10.1            # via flask
 jmespath==0.9.4           # via boto3, botocore
-kmsauth==0.6.0
-lru-dict==1.1.6
+kmsauth==0.6.0            # via -r ./requirements.in
+lru-dict==1.1.6           # via -r ./requirements.in
 lxml==4.4.1               # via xmlsec
 markupsafe==1.1.1         # via jinja2
-more-itertools==8.0.2     # via pytest, zipp
-ndg-httpsclient==0.5.1
+more-itertools==8.0.2     # via pytest
+ndg-httpsclient==0.5.1    # via -r ./requirements.in
 packaging==20.0           # via pytest
 pkgconfig==1.5.1          # via xmlsec
 pluggy==0.13.1            # via pytest
 py==1.8.1                 # via pytest
-pyasn1==0.4.6
+pyasn1==0.4.6             # via -r ./requirements.in, ndg-httpsclient
 pycparser==2.19           # via cffi
-pynamodb==3.4.1
-pyopenssl==19.0.0
+pynamodb==3.4.1           # via -r ./requirements.in
+pyopenssl==19.0.0         # via -r ./requirements.in, ndg-httpsclient
 pyparsing==2.4.6          # via packaging
-pytest-cov==2.8.1
-pytest-env==0.6.2
-pytest-gevent==1.0.0
-pytest-lazy-fixture==0.6.1
-pytest-mock==1.11.2
-pytest==4.6.9
+pytest-cov==2.8.1         # via -r ./requirements.in
+pytest-env==0.6.2         # via -r ./requirements.in
+pytest-gevent==1.0.0      # via -r ./requirements.in
+pytest-lazy-fixture==0.6.1  # via -r ./requirements.in
+pytest-mock==1.11.2       # via -r ./requirements.in
+pytest==4.6.9             # via -r ./requirements.in, pytest-cov, pytest-env, pytest-gevent, pytest-lazy-fixture, pytest-mock
 python-dateutil==2.8.0    # via botocore, pynamodb
-python-json-logger==0.1.11
-python3-saml==1.9.0
-pytz==2019.1
-pyyaml==5.1.2
-redis==2.10.3
-requests==2.22.0
+python-json-logger==0.1.11  # via -r ./requirements.in
+python3-saml==1.9.0       # via -r ./requirements.in
+pytz==2019.1              # via -r ./requirements.in
+pyyaml==5.3.1             # via -r ./requirements.in
+redis==2.10.3             # via -r ./requirements.in
+requests==2.22.0          # via -r ./requirements.in
 s3transfer==0.2.1         # via boto3
 six==1.12.0               # via cryptography, isodate, packaging, pynamodb, pyopenssl, pytest, python-dateutil
-statsd==3.2.1
-toastedmarshmallow==2.15.2.post1
+statsd==3.2.1             # via -r ./requirements.in
+toastedmarshmallow==2.15.2.post1  # via -r ./requirements.in
 urllib3==1.25.3           # via botocore, requests
 wcwidth==0.1.8            # via pytest
 werkzeug==0.15.6          # via flask


### PR DESCRIPTION
Github actions is failing with a combination of python 3.7.8 and pyyaml 5.1.2.  This PR updates pyyaml to 5.3.1.

https://github.com/actions/virtual-environments/issues/1202