### PR TITLE
Add requirements.in to MANIFEST.in for pip install

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include VERSION
 recursive-include confidant/dist *
 include requirements.txt
+include requirements.in


### PR DESCRIPTION
Fixes #311, since setup.py pulls in requirements.in.