### PR TITLE
Don't allow whitespace in credential keys

### DIFF
--- a/confidant/services/credentialmanager.py
+++ b/confidant/services/credentialmanager.py
@@ -1,11 +1,11 @@
 import copy
-
-from pynamodb.exceptions import DoesNotExist
+import re
 
 from confidant import settings
-from confidant.utils import stats
-from confidant.models.credential import Credential
 from confidant.models.blind_credential import BlindCredential
+from confidant.models.credential import Credential
+from confidant.utils import stats
+from pynamodb.exceptions import DoesNotExist
 
 
 def get_credentials(credential_ids):
@@ -58,6 +58,9 @@ def check_credential_pair_values(credential_pairs):
     for key, val in credential_pairs.items():
         if isinstance(val, dict) or isinstance(val, list):
             ret = {'error': 'credential pairs must be key: value'}
+            return (False, ret)
+        if re.search(r'\s', key):
+            ret = {'error': 'credential key must not contain whitespace'}
             return (False, ret)
     return (True, {})
 

--- a/tests/unit/confidant/services/credentialmanager_test.py
+++ b/tests/unit/confidant/services/credentialmanager_test.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from confidant.models.credential import Credential
 from confidant.services import credentialmanager
 from pynamodb.exceptions import DoesNotExist
@@ -47,9 +45,14 @@ def test_check_credential_pair_values(mocker):
     cred_pair_fail_2 = {
         'A': {'1': '2'}
     }
+    cred_pair_fail_3 = {
+        'A A': {'1': '2'}
+    }
     result = credentialmanager.check_credential_pair_values(cred_pairs_fail)
     assert result[0] is False
     result = credentialmanager.check_credential_pair_values(cred_pair_fail_2)
+    assert result[0] is False
+    result = credentialmanager.check_credential_pair_values(cred_pair_fail_3)
     assert result[0] is False
     result = credentialmanager.check_credential_pair_values(cred_pairs_success)
     assert result[0] is True


### PR DESCRIPTION
Cred keys will eventually be translated into variables.  This PR begins introducing some key input sanitization by preventing whitespace.