### PR TITLE
Bug fix in logic that allows checking if a user is allowed to decrypt a credential

### DIFF
--- a/confidant/public/modules/resources/controllers/CredentialDetailsCtrl.js
+++ b/confidant/public/modules/resources/controllers/CredentialDetailsCtrl.js
@@ -53,6 +53,7 @@
             $scope.definedTags = $scope.clientconfig.generated.defined_tags;
             $scope.credentialId = $stateParams.credentialId;
             $scope.showCredentials = false;
+            $scope.decryptedCredential = false;
 
             function populateCredential(credential) {
                 var _credentialPairs = [],
@@ -196,6 +197,7 @@
                     Credential.get({'id': $scope.credentialId, 'metadata_only': false}).$promise.then(function(credential) {
                         populateCredential(credential);
                         $scope.showCredentials = true;
+                        $scope.decryptedCredential = true;
                     }, function(res) {
                         if (res.status === 500) {
                             $scope.getError = 'Unexpected server error.';

--- a/confidant/public/modules/resources/views/credential-details.html
+++ b/confidant/public/modules/resources/views/credential-details.html
@@ -41,7 +41,7 @@
       <label for="credentialEnabled">Credential Enabled</label>
       <span editable-checkbox="credential.enabled" id="credentialEnabled">{{ credential.enabled }}</span>
     </div>
-    <div class="form-group" ng-show="credential.id && hasMetadata && !credential.permissions.get">
+    <div class="form-group" ng-show="credential.id && hasMetadata && !decryptedCredential">
       <label for="credentialKeys">Credential Keys</label>
           <div class="well well-sm">
               <ul id="credential.credential_keys" class="list-unstyled">

--- a/confidant/routes/credentials.py
+++ b/confidant/routes/credentials.py
@@ -180,7 +180,11 @@ def get_credential(id):
 
     permissions = {
         'metadata': True,
-        'get': False,
+        'get': acl_module_check(
+            resource_type='credential',
+            action='get',
+            resource_id=id
+        ),
         'update': acl_module_check(
             resource_type='credential',
             action='update',


### PR DESCRIPTION
When grabbing metadata of a credential, also check if the user has permissions to decrypt the credential.

This allows us to appropriately show or hide the lock.