### PR TITLE
Don't show decrypt icon if user does not have get permissions

### DIFF
--- a/confidant/public/modules/resources/views/credential-details.html
+++ b/confidant/public/modules/resources/views/credential-details.html
@@ -51,7 +51,7 @@
               </ul>
         </div>
     </div>
-    <div class="form-group" ng-show="credential.permissions.get || globalPermissions.credentials.create">
+    <div class="form-group" ng-show="credential.permissions.get">
       <label for="credentialPairInputs">Credential Pairs
         <span class="glyphicon glyphicon-lock" data-toggle="tooltip" title="This attribute is encrypted at-rest"></span>
         <span ng-show="!editableForm.$visible">


### PR DESCRIPTION
Users were being incorrectly shown decrypt icon on credentials where they had the ability to `create` credentials but didn't have `get` (decrypt) permissions.  

This change shows the option to decrypt credentials only if they have  decrypt permissions
