### PR TITLE
Revert "link to infradocs (#338)"

### DIFF
--- a/confidant/routes/services.py
+++ b/confidant/routes/services.py
@@ -554,9 +554,7 @@ def map_service_credentials(id):
           }
     ):
         msg = ("{} does not have access to map the credentials "
-               "because they do not own the credentials being added. "
-               "See https://infradocs.lyft.net/develop/credentials/"
-               "credential-access.html#accessing-credentials-in-confidant")
+               "because they do not own the credentials being added")
         msg = msg.format(authnz.get_logged_in_user())
         error_msg = {'error': msg, 'reference': id}
         return jsonify(error_msg), 403


### PR DESCRIPTION
This reverts commit 2a24616635f7b0cba949f2c4a7f0fadb75a906d1.

The previous commit had a link to Lyft internal documentation.