### PR TITLE
Fixed @ CVE-2022-2309

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -84,7 +84,7 @@ kmsauth==0.6.0
     # via -r requirements.in
 lru-dict==1.1.6
     # via -r requirements.in
-lxml==4.6.5
+lxml==4.9.1
     # via xmlsec
 markupsafe==2.0.1
     # via jinja2
@@ -171,9 +171,9 @@ werkzeug==1.0.1
     # via flask
 xmlsec==1.3.3
     # via python3-saml
-zope.event==4.5.0
+zope-event==4.5.0
     # via gevent
-zope.interface==5.4.0
+zope-interface==5.4.0
     # via gevent
 
 # The following packages are considered to be unsafe in a requirements file:


### PR DESCRIPTION
NULL Pointer Dereference allows attackers to cause a denial of service (or application crash). This only applies when lxml is used together with libxml2 2.9.10 through 2.9.14. libxml2 2.9.9 and earlier are not affected. It allows triggering crashes through forged input data, given a vulnerable code sequence in the application. The vulnerability is caused by the iterwalk function (also used by the canonicalize function). Such code shouldn't be in wide-spread use, given that parsing + iterwalk would usually be replaced with the more efficient iterparse function. However, an XML converter that serialises to C14N would also be vulnerable, for example, and there are legitimate use cases for this code sequence. If untrusted input is received (also remotely) and processed via iterwalk function, a crash can be triggered.

**CVE-2022-2309**
`CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H`
GHSA-wrxv-2j5q-m38w
