### PR TITLE
Add stats to jwtkmanager

### DIFF
--- a/confidant/services/jwkmanager.py
+++ b/confidant/services/jwkmanager.py
@@ -82,7 +82,7 @@ class JWKManager:
             'expiry': expiry,
             'token': token
         }
-        stats.incr('get_jwt.cache.miss')
+        stats.incr('get_jwt.create')
         return token
 
     def _get_public_key(self, alias: str, certificate: str,


### PR DESCRIPTION
Allows us to obtain metrics on `get_jwt`  function so we graph latency on jwt encoding, jwt cache hits and misses.