### PR TITLE
Support multiple keys per environment

### DIFF
--- a/confidant/routes/jwks.py
+++ b/confidant/routes/jwks.py
@@ -90,7 +90,7 @@ def get_public_jwks(environment):
     """
     jwks = jwk_manager.get_jwks(environment)
     if jwks:
-        return jwks_list_response_schema.dumps(JWKSListResponse(keys=[jwks]))
+        return jwks_list_response_schema.dumps(JWKSListResponse(keys=jwks))
 
     response = jsonify({
         'error': 'Public key not found for this environment'

--- a/confidant/services/jwkmanager.py
+++ b/confidant/services/jwkmanager.py
@@ -63,9 +63,11 @@ class JWKManager:
 
         if kid not in self._pem_cache[environment]:
             # setting either way to avoid further lookups when response is None
-            self._pem_cache[environment][kid] = self._keys[environment].get_key(kid)
+            self._pem_cache[environment][kid] = \
+                self._keys[environment].get_key(kid)
             if self._pem_cache[environment][kid]:
-                self._pem_cache[environment][kid] = self._pem_cache[environment][kid].export_to_pem(
+                self._pem_cache[environment][kid] = \
+                    self._pem_cache[environment][kid].export_to_pem(
                     private_key=True,
                     password=None
                 )
@@ -116,7 +118,6 @@ class JWKManager:
         }
         stats.incr('get_jwt.create')
         return token
-
 
     def get_active_key(self, environment: str) -> jwk.JWK:
         if environment in ACTIVE_SIGNING_KEYS and environment in self._keys:

--- a/confidant/services/jwkmanager.py
+++ b/confidant/services/jwkmanager.py
@@ -121,7 +121,7 @@ class JWKManager:
 
     def get_active_key(self, environment: str) -> jwk.JWK:
         if environment in ACTIVE_SIGNING_KEYS and environment in self._keys:
-            return self._keys[environment]._get_key(
+            return self._keys[environment].get_key(
                 ACTIVE_SIGNING_KEYS[environment],
                 environment
             )

--- a/confidant/services/jwkmanager.py
+++ b/confidant/services/jwkmanager.py
@@ -2,7 +2,7 @@ import logging
 import jwt
 
 from jwcrypto import jwk
-from typing import Dict, Optional
+from typing import Dict, Optional, List
 
 from confidant.settings import CERTIFICATE_AUTHORITIES, \
     DEFAULT_JWT_EXPIRATION_SECONDS, JWT_CACHING_ENABLED, ACTIVE_SIGNING_KEYS
@@ -60,7 +60,7 @@ class JWKManager:
     def _get_key(self, kid: str, environment: str):
         if environment not in self._pem_cache:
             self._pem_cache[environment] = {}
-            
+
         if kid not in self._pem_cache[environment]:
             # setting either way to avoid further lookups when response is None
             self._pem_cache[environment][kid] = self._keys[environment].get_key(kid)

--- a/confidant/services/jwkmanager.py
+++ b/confidant/services/jwkmanager.py
@@ -18,7 +18,6 @@ logger = logging.getLogger(__name__)
 CA_SCHEMA = {
     'crt': {'type': 'string', 'required': True},
     'key': {'type': 'string', 'required': True},
-    'name': {'type': 'string', 'required': True},
     'passphrase': {'type': 'string', 'required': True},
     'kid': {'type': 'string', 'required': True},
 }
@@ -36,12 +35,13 @@ class JWKManager:
     def _load_certificate_authorities(self) -> None:
         validator = Validator(CA_SCHEMA)
         if CERTIFICATE_AUTHORITIES:
-            for ca in CERTIFICATE_AUTHORITIES:
-                if validator.validate(ca):
-                    self.set_key(ca['name'], ca['kid'], ca['key'],
-                                 passphrase=ca['passphrase'])
-                else:
-                    logger.error('Invalid entry in CERTIFICATE_AUTHORITIES')
+            for environment in CERTIFICATE_AUTHORITIES:
+                for ca in CERTIFICATE_AUTHORITIES[environment]:
+                    if validator.validate(ca):
+                        self.set_key(environment, ca['kid'], ca['key'],
+                                     passphrase=ca['passphrase'])
+                    else:
+                        logger.error(f'Invalid entry in {environment} in CERTIFICATE_AUTHORITIES')
 
     def set_key(self, environment: str, kid: str,
                 private_key: str,

--- a/confidant/services/jwkmanager.py
+++ b/confidant/services/jwkmanager.py
@@ -121,7 +121,7 @@ class JWKManager:
 
     def get_active_key(self, environment: str) -> jwk.JWK:
         if environment in ACTIVE_SIGNING_KEYS and environment in self._keys:
-            return self._keys[environment].get_key(
+            return self._get_key(
                 ACTIVE_SIGNING_KEYS[environment],
                 environment
             )

--- a/confidant/services/jwkmanager.py
+++ b/confidant/services/jwkmanager.py
@@ -41,7 +41,8 @@ class JWKManager:
                         self.set_key(environment, ca['kid'], ca['key'],
                                      passphrase=ca['passphrase'])
                     else:
-                        logger.error(f'Invalid entry in {environment} in CERTIFICATE_AUTHORITIES')
+                        logger.error(f'Invalid entry in {environment} '
+                                     f'in CERTIFICATE_AUTHORITIES')
 
     def set_key(self, environment: str, kid: str,
                 private_key: str,

--- a/confidant/services/jwkmanager.py
+++ b/confidant/services/jwkmanager.py
@@ -1,19 +1,32 @@
+import logging
 import jwt
 
 from jwcrypto import jwk
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, List
 from hashlib import sha1
 from cryptography.x509 import load_pem_x509_certificate
 from cryptography.hazmat.primitives import serialization
 from confidant.settings import CERTIFICATE_AUTHORITIES, \
-    DEFAULT_JWT_EXPIRATION_SECONDS, JWT_CACHING_ENABLED
+    DEFAULT_JWT_EXPIRATION_SECONDS, JWT_CACHING_ENABLED, ACTIVE_SIGNING_KEYS
 from confidant.utils import stats
 from datetime import datetime, timezone, timedelta
+from cerberus import Validator
+
+
+logger = logging.getLogger(__name__)
+
+CA_SCHEMA = {
+    'crt': {'type': 'string', 'required': True},
+    'key': {'type': 'string', 'required': True},
+    'name': {'type': 'string', 'required': True},
+    'passphrase': {'type': 'string', 'required': True},
+    'kid': {'type': 'string', 'required': True},
+}
 
 
 class JWKManager:
     def __init__(self) -> None:
-        self._keys = jwk.JWKSet()
+        self._keys = {}
         self._public_keys = {}
         self._token_cache = {}
         self._payload_cache = {}
@@ -21,45 +34,53 @@ class JWKManager:
         self._load_certificate_authorities()
 
     def _load_certificate_authorities(self) -> None:
+        validator = Validator(CA_SCHEMA)
         if CERTIFICATE_AUTHORITIES:
             for ca in CERTIFICATE_AUTHORITIES:
-                self.set_key(ca['name'], ca['key'],
-                             passphrase=ca['passphrase'])
+                if validator.validate(ca):
+                    self.set_key(ca['name'], ca['kid'], ca['key'],
+                                 passphrase=ca['passphrase'])
+                else:
+                    logger.error('Invalid entry in CERTIFICATE_AUTHORITIES')
 
-    def set_key(self, kid: str, private_key: str,
+    def set_key(self, environment: str, kid: str,
+                private_key: str,
                 passphrase: Optional[str] = None,
                 encoding: str = 'utf-8') -> str:
+        if environment not in self._keys:
+            self._keys[environment] = jwk.JWKSet()
+
         if passphrase:
             passphrase = passphrase.encode(encoding)
         key = jwk.JWK()
         key.import_from_pem(private_key.encode(encoding),
                             password=passphrase, kid=kid)
-        if not self._keys.get_key(kid):
-            self._keys.add(key)
+        if not self._keys[environment].get_key(kid):
+            self._keys[environment].add(key)
         return kid
 
-    def get_jwt(self, kid: str, payload: dict,
+    def get_jwt(self, environment: str, payload: dict,
                 expiration_seconds: int = DEFAULT_JWT_EXPIRATION_SECONDS,
                 algorithm: str = 'RS256') -> str:
-        key = self._keys.get_key(kid)
+        key = self.get_active_key(environment)
         if not key:
-            raise ValueError('This private key is not stored!')
+            raise ValueError('No active key for this environment')
 
         if 'user' not in payload:
             raise ValueError('Please include the user in the payload')
 
-        if kid not in self._token_cache:
-            self._token_cache[kid] = {}
+        if key.key_id not in self._token_cache:
+            self._token_cache[key.key_id] = {}
 
         user = payload['user']
         now = datetime.now(tz=timezone.utc)
 
         # return token from cache
-        if user in self._token_cache[kid].keys() \
+        if user in self._token_cache[key.key_id].keys() \
                 and JWT_CACHING_ENABLED:
-            if now < self._token_cache[kid][user]['expiry']:
+            if now < self._token_cache[key.key_id][user]['expiry']:
                 stats.incr('get_jwt.cache.hit')
-                return self._token_cache[kid][user]['token']
+                return self._token_cache[key.key_id][user]['token']
 
         # cache miss, generate new token and update cache
         expiry = now + timedelta(seconds=expiration_seconds)
@@ -73,12 +94,12 @@ class JWKManager:
             # XXX: TODO: cache export_to_pem
             token = jwt.encode(
                 payload=payload,
-                headers={'kid': kid},
+                headers={'kid': key.key_id},
                 key=key.export_to_pem(private_key=True, password=None),
                 algorithm=algorithm,
             )
 
-        self._token_cache[kid][user] = {
+        self._token_cache[key.key_id][user] = {
             'expiry': expiry,
             'token': token
         }
@@ -115,14 +136,24 @@ class JWKManager:
 
         return self._payload_cache[certificate_hash][token_hash]
 
-    def get_jwks(self, key_id: str, algorithm: str = 'RS256') -> Dict[str, str]:
-        key = self._keys.get_key(key_id)
-        if key:
-            stats.incr(f'get_jwks.{key_id}.hit')
-            return {**key.export_public(as_dict=True), 'alg': algorithm}
+    def get_active_key(self, environment: str) -> jwk.JWK:
+        if environment in ACTIVE_SIGNING_KEYS and environment in self._keys:
+            return self._keys[environment].get_key(
+                ACTIVE_SIGNING_KEYS[environment]
+            )
+
+    def get_jwks(self, environment: str, algorithm: str = 'RS256') \
+            -> List[Dict[str, str]]:
+        keys = self._keys.get(environment)
+        if keys:
+            stats.incr(f'get_jwks.{environment}.hit')
+            return [{
+                **key.export_public(as_dict=True),
+                'alg': algorithm
+            } for key in keys]
         else:
-            stats.incr(f'get_jwks.{key_id}.miss')
-            return {}
+            stats.incr(f'get_jwks.{environment}.miss')
+            return []
 
 
 jwk_manager = JWKManager()

--- a/confidant/settings.py
+++ b/confidant/settings.py
@@ -636,3 +636,4 @@ def get(name, default=None):
 # Module that will perform an external ACL check on API endpoints
 ACL_MODULE = str_env('ACL_MODULE', 'confidant.authnz.rbac:default_acl')
 DEFAULT_JWT_EXPIRATION_SECONDS = int_env('DEFAULT_JWT_EXPIRATION_SECONDS', 3600)
+ACTIVE_SIGNING_KEYS = json.loads(str_env('ACTIVE_SIGNING_KEYS', '{}'))

--- a/confidant/settings.py
+++ b/confidant/settings.py
@@ -606,6 +606,17 @@ ROTATION_DAYS_CONFIG = json.loads(str_env('ROTATION_DAYS_CONFIG', '{}'))
 ENABLE_SAVE_LAST_DECRYPTION_TIME = bool_env('ENABLE_SAVE_LAST_DECRYPTION_TIME')
 
 # Add any certificate authorities
+# Should be in encrypted settings following this format (where name is
+# the name of the environment) and key ids must be unique:
+# [
+# {
+#   "key": "--- RSA...",
+#   "crt": "--- CERT...",
+#   "name": "staging",
+#   "passphrase": "some-key",
+#   "kid": "some-kid"
+# }, ...
+# ]
 decrypted_cas = encrypted_settings.decrypted_secrets.get(
     'CERTIFICATE_AUTHORITIES'
 )
@@ -636,4 +647,8 @@ def get(name, default=None):
 # Module that will perform an external ACL check on API endpoints
 ACL_MODULE = str_env('ACL_MODULE', 'confidant.authnz.rbac:default_acl')
 DEFAULT_JWT_EXPIRATION_SECONDS = int_env('DEFAULT_JWT_EXPIRATION_SECONDS', 3600)
+
+# Key IDs from CERTIFICATE_AUTHORITIES that should be used to sign new JWTs,
+# provide a JSON with the following format:
+# {"staging": "some_kid", "production": "some_kid"}
 ACTIVE_SIGNING_KEYS = json.loads(str_env('ACTIVE_SIGNING_KEYS', '{}'))

--- a/requirements.in
+++ b/requirements.in
@@ -194,3 +194,4 @@ pytz
 # for jwt
 pyjwt>=2.6.0
 jwcrypto
+cerberus

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,6 +23,8 @@ botocore==1.12.227
     #   boto3
     #   pynamodb
     #   s3transfer
+cerberus==1.3.4
+    # via -r requirements.in
 certifi==2019.6.16
     # via requests
 cffi==1.14.5

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -133,7 +133,7 @@ def test_jwks():
     return {
         'alg': 'RS256',
         'e': 'AQAB',
-        'kid': 'test-key',
+        'kid': '0h7R8dL0rU-b3p3onft_BPfuRW1Ld7YjsFnOWJuFXUE',
         'kty': 'RSA',
         'n': '1LtU2hUlTSRC32IlfvtWQwG60P35aK-uFzsCvUSLc2Kr5xFFNfmh8OELwzci'
              'ibMh-_7qr-Nrw2YgogB-k9UVSw99AHSLMDkKVUrEHDxF3CX5CCd2UElqbk1T'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,61 @@ import pytest
 from jwcrypto import jwk
 
 
+TEST_PRIVATE_KEY = \
+    b'-----BEGIN PRIVATE KEY-----\n' \
+    b'MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQDUu1TaFSVNJELf\n' \
+    b'YiV++1ZDAbrQ/flor64XOwK9RItzYqvnEUU1+aHw4QvDNyKJsyH7/uqv42vDZiCi\n' \
+    b'AH6T1RVLD30AdIswOQpVSsQcPEXcJfkIJ3ZQSWpuTVMbvJukrWK9ScPFkUyBC7Fp\n' \
+    b'kZ/RJ6pwiE2nVHjcrysAmK2/KB1Hk/NmO+fwevIcYXwrxNLm9k6XM5xyJcl7ZK3G\n' \
+    b'InZbuEcH4NdRYnAo7dCLtuwRFUW4fgSRUjjxFXGJLd830iDgHzM0VyTq77gzKpn5\n' \
+    b'VEZbIvDWgc8oxKHsrJKbyv3UGeC0q04K2EQR6tq71gbS/hv9QCxmR6ygNqq8bz0d\n' \
+    b'smZXeeYxAgMBAAECggEActo9Io0eGXsFW8OKiPc7iGvLqAAnAt0uub4TaYozW/We\n' \
+    b'598MJesEAqAOELSYwg1jwMDNhm7bhKCD59Mqg7gciezvySoi58M0D/6QyMnF0ejy\n' \
+    b'ffOITiqE+s5mm2gGBC/USmwj9WvQCS/99gg4Z9zpiV4dxsS1iDhOmEDWNYl73WNH\n' \
+    b'4aXL6fxG59r943qpm3JJqqqW/wsFQELLrKDrSWCv6u4niJ/zBE/XS6GaeZRm5ZNI\n' \
+    b'BxSRwuYQgNzFdi/cGLV3BPiwusT37pANvzCI+1ZUazKFVjTHPPdvFvpoFap24Foo\n' \
+    b'IkVdpe4Fm6qbi66uCUXlXPyGbmA1lkmmskACE4/7kQKBgQD75RxndWb90YvJAjhL\n' \
+    b'nDiXu8xe4p0wsDoFNGDuLag1ZKhkHfN3YG7PwZY+1aXUP0fgpGM9ivjWgctosmcR\n' \
+    b'nHPnyUi846PWNV5KQPFzR1Fmg8xAr0LdeyZHZetQYB+21QvMdfFsU1qU0rhU07Og\n' \
+    b'4CGVIJBZCpbMxSN4MCy57jFdvQKBgQDYMtWP7A2HwA0zxwn0rciF0VoTM6XERkz5\n' \
+    b'nwrnYneFiiShMjUOrLxq5XSU3sawIw/MD0gRsbDkv3kMdGf32sjsopLKFSk8aXid\n' \
+    b'BpLoaE7TRzSwJhmFSGNa4s3HBXqEjXJIgDDz3XlvZ/8h9WCQg/tJQ6IaV0oSx1q5\n' \
+    b'bpO258CvhQKBgE6gqKoeuoRWKYUYHUx0ujGa3GNt51UwXRwMyojuVYg9IFcIBlxo\n' \
+    b'DI7rRaPdesLy8dPMXHH0dFI49655qbSUmpVqfjr/779Ir2MMPJIYW+9dCp/SVVPf\n' \
+    b'QgadaMORDbU7cVBkLHT829SCpilMX9DCxZjQLl6s8H+Atd6pYvyyvlQdAoGAVGo8\n' \
+    b'0s4zVj7ZqM7dh0jXk9BzYC35WpKseYbs5f2fd2fB96K37rvpcb+X7oyxfZKjF2Uc\n' \
+    b'GbSMwjQ02nUVJ0So0SSFNhxfFnSEIKOxdsdLh9k0rFaj/lOOX61Q9ZWhCeKEreRH\n' \
+    b'uOBQCvzLNIIvqx2tXyTmRWyxwnVOajrPuEnzBVUCgYAKBdA3UC+Cu4f5nhn8FmG3\n' \
+    b'YuTBwFrUB82BHCQxC7L3prsxWVuguZptWln0ng+yTQme+shre03BaONl7A95hfz5\n' \
+    b'rhXTb8j86oFR6JIYf2Vfe6hrUBCxAxb4A1uDkt/GZMupHp+XiKCY8L+nKPjbX8aC\n' \
+    b'PmsiJweOFGfkN7QBzsdhsg==\n' \
+    b'-----END PRIVATE KEY-----\n'
+
+TEST_CERTIFICATE = \
+    b'-----BEGIN CERTIFICATE-----\n' \
+    b'MIIDoDCCAogCCQDqKOyH38qgKDANBgkqhkiG9w0BAQsFADCBkTELMAkGA1UEBhMC\n' \
+    b'VVMxCzAJBgNVBAgMAkNBMRYwFAYDVQQHDA1UZXN0IExvY2FsaXR5MRIwEAYDVQQK\n' \
+    b'DAlMeWZ0IFRlc3QxEjAQBgNVBAsMCVRlc3QgVW5pdDENMAsGA1UEAwwEdGVzdDEm\n' \
+    b'MCQGCSqGSIb3DQEJARYXdGVzdC1zb21ldGhpbmdAbHlmdC5jb20wHhcNMjIxMDA3\n' \
+    b'MjMxNTM5WhcNMjMxMDA3MjMxNTM5WjCBkTELMAkGA1UEBhMCVVMxCzAJBgNVBAgM\n' \
+    b'AkNBMRYwFAYDVQQHDA1UZXN0IExvY2FsaXR5MRIwEAYDVQQKDAlMeWZ0IFRlc3Qx\n' \
+    b'EjAQBgNVBAsMCVRlc3QgVW5pdDENMAsGA1UEAwwEdGVzdDEmMCQGCSqGSIb3DQEJ\n' \
+    b'ARYXdGVzdC1zb21ldGhpbmdAbHlmdC5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IB\n' \
+    b'DwAwggEKAoIBAQDUu1TaFSVNJELfYiV++1ZDAbrQ/flor64XOwK9RItzYqvnEUU1\n' \
+    b'+aHw4QvDNyKJsyH7/uqv42vDZiCiAH6T1RVLD30AdIswOQpVSsQcPEXcJfkIJ3ZQ\n' \
+    b'SWpuTVMbvJukrWK9ScPFkUyBC7FpkZ/RJ6pwiE2nVHjcrysAmK2/KB1Hk/NmO+fw\n' \
+    b'evIcYXwrxNLm9k6XM5xyJcl7ZK3GInZbuEcH4NdRYnAo7dCLtuwRFUW4fgSRUjjx\n' \
+    b'FXGJLd830iDgHzM0VyTq77gzKpn5VEZbIvDWgc8oxKHsrJKbyv3UGeC0q04K2EQR\n' \
+    b'6tq71gbS/hv9QCxmR6ygNqq8bz0dsmZXeeYxAgMBAAEwDQYJKoZIhvcNAQELBQAD\n' \
+    b'ggEBAIPQnGGAlwbK+f4V7SUUjXnsO7oVlMtTO7JWAk+g8W9colUeMDHW/Ygcwu3e\n' \
+    b'OlX5NSEV1wcQxuqyNWbEgrsZourePdVWujc/9qSVfaU/BjOj2CLylAf6ZNj/XpL/\n' \
+    b'PNCSCLM40cbhw/SeiNZ9WxkuuHiC32QxmR4kyvvXcHEGqVA2cOVAvncstW4gGowi\n' \
+    b'ObNYddXOmoOf8d5oHcO5vlhYyfbmShuq1PLygzUhG2jS+5aX9gmDtv+LtVGdXXWV\n' \
+    b'zSCh3+H4NSUWs3P1pKDFIUT3jGLQ3UavIS5KCizfBUbltx6LBSgmBbHf89RsKBbT\n' \
+    b'rxaukysD4sNgVHKptTq0fJ+2CjM=\n' \
+    b'-----END CERTIFICATE-----\n'
+
+
 @pytest.fixture(autouse=True)
 def encrypted_settings_mock(mocker):
     mocker.patch('confidant.settings.encrypted_settings.secret_string', {})
@@ -49,37 +104,8 @@ def test_encrypted_key():
 
 @pytest.fixture
 def test_key_pair():
-    test_private_key = \
-        b'-----BEGIN PRIVATE KEY-----\n' \
-        b'MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQDUu1TaFSVNJELf\n' \
-        b'YiV++1ZDAbrQ/flor64XOwK9RItzYqvnEUU1+aHw4QvDNyKJsyH7/uqv42vDZiCi\n' \
-        b'AH6T1RVLD30AdIswOQpVSsQcPEXcJfkIJ3ZQSWpuTVMbvJukrWK9ScPFkUyBC7Fp\n' \
-        b'kZ/RJ6pwiE2nVHjcrysAmK2/KB1Hk/NmO+fwevIcYXwrxNLm9k6XM5xyJcl7ZK3G\n' \
-        b'InZbuEcH4NdRYnAo7dCLtuwRFUW4fgSRUjjxFXGJLd830iDgHzM0VyTq77gzKpn5\n' \
-        b'VEZbIvDWgc8oxKHsrJKbyv3UGeC0q04K2EQR6tq71gbS/hv9QCxmR6ygNqq8bz0d\n' \
-        b'smZXeeYxAgMBAAECggEActo9Io0eGXsFW8OKiPc7iGvLqAAnAt0uub4TaYozW/We\n' \
-        b'598MJesEAqAOELSYwg1jwMDNhm7bhKCD59Mqg7gciezvySoi58M0D/6QyMnF0ejy\n' \
-        b'ffOITiqE+s5mm2gGBC/USmwj9WvQCS/99gg4Z9zpiV4dxsS1iDhOmEDWNYl73WNH\n' \
-        b'4aXL6fxG59r943qpm3JJqqqW/wsFQELLrKDrSWCv6u4niJ/zBE/XS6GaeZRm5ZNI\n' \
-        b'BxSRwuYQgNzFdi/cGLV3BPiwusT37pANvzCI+1ZUazKFVjTHPPdvFvpoFap24Foo\n' \
-        b'IkVdpe4Fm6qbi66uCUXlXPyGbmA1lkmmskACE4/7kQKBgQD75RxndWb90YvJAjhL\n' \
-        b'nDiXu8xe4p0wsDoFNGDuLag1ZKhkHfN3YG7PwZY+1aXUP0fgpGM9ivjWgctosmcR\n' \
-        b'nHPnyUi846PWNV5KQPFzR1Fmg8xAr0LdeyZHZetQYB+21QvMdfFsU1qU0rhU07Og\n' \
-        b'4CGVIJBZCpbMxSN4MCy57jFdvQKBgQDYMtWP7A2HwA0zxwn0rciF0VoTM6XERkz5\n' \
-        b'nwrnYneFiiShMjUOrLxq5XSU3sawIw/MD0gRsbDkv3kMdGf32sjsopLKFSk8aXid\n' \
-        b'BpLoaE7TRzSwJhmFSGNa4s3HBXqEjXJIgDDz3XlvZ/8h9WCQg/tJQ6IaV0oSx1q5\n' \
-        b'bpO258CvhQKBgE6gqKoeuoRWKYUYHUx0ujGa3GNt51UwXRwMyojuVYg9IFcIBlxo\n' \
-        b'DI7rRaPdesLy8dPMXHH0dFI49655qbSUmpVqfjr/779Ir2MMPJIYW+9dCp/SVVPf\n' \
-        b'QgadaMORDbU7cVBkLHT829SCpilMX9DCxZjQLl6s8H+Atd6pYvyyvlQdAoGAVGo8\n' \
-        b'0s4zVj7ZqM7dh0jXk9BzYC35WpKseYbs5f2fd2fB96K37rvpcb+X7oyxfZKjF2Uc\n' \
-        b'GbSMwjQ02nUVJ0So0SSFNhxfFnSEIKOxdsdLh9k0rFaj/lOOX61Q9ZWhCeKEreRH\n' \
-        b'uOBQCvzLNIIvqx2tXyTmRWyxwnVOajrPuEnzBVUCgYAKBdA3UC+Cu4f5nhn8FmG3\n' \
-        b'YuTBwFrUB82BHCQxC7L3prsxWVuguZptWln0ng+yTQme+shre03BaONl7A95hfz5\n' \
-        b'rhXTb8j86oFR6JIYf2Vfe6hrUBCxAxb4A1uDkt/GZMupHp+XiKCY8L+nKPjbX8aC\n' \
-        b'PmsiJweOFGfkN7QBzsdhsg==\n' \
-        b'-----END PRIVATE KEY-----\n'
     test_pair = jwk.JWK()
-    test_pair.import_from_pem(test_private_key)
+    test_pair.import_from_pem(TEST_PRIVATE_KEY)
     return test_pair
 
 
@@ -103,30 +129,7 @@ def test_jwt():
 
 @pytest.fixture
 def test_certificate():
-    cert = \
-        b'-----BEGIN CERTIFICATE-----\n' \
-        b'MIIDoDCCAogCCQDqKOyH38qgKDANBgkqhkiG9w0BAQsFADCBkTELMAkGA1UEBhMC\n' \
-        b'VVMxCzAJBgNVBAgMAkNBMRYwFAYDVQQHDA1UZXN0IExvY2FsaXR5MRIwEAYDVQQK\n' \
-        b'DAlMeWZ0IFRlc3QxEjAQBgNVBAsMCVRlc3QgVW5pdDENMAsGA1UEAwwEdGVzdDEm\n' \
-        b'MCQGCSqGSIb3DQEJARYXdGVzdC1zb21ldGhpbmdAbHlmdC5jb20wHhcNMjIxMDA3\n' \
-        b'MjMxNTM5WhcNMjMxMDA3MjMxNTM5WjCBkTELMAkGA1UEBhMCVVMxCzAJBgNVBAgM\n' \
-        b'AkNBMRYwFAYDVQQHDA1UZXN0IExvY2FsaXR5MRIwEAYDVQQKDAlMeWZ0IFRlc3Qx\n' \
-        b'EjAQBgNVBAsMCVRlc3QgVW5pdDENMAsGA1UEAwwEdGVzdDEmMCQGCSqGSIb3DQEJ\n' \
-        b'ARYXdGVzdC1zb21ldGhpbmdAbHlmdC5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IB\n' \
-        b'DwAwggEKAoIBAQDUu1TaFSVNJELfYiV++1ZDAbrQ/flor64XOwK9RItzYqvnEUU1\n' \
-        b'+aHw4QvDNyKJsyH7/uqv42vDZiCiAH6T1RVLD30AdIswOQpVSsQcPEXcJfkIJ3ZQ\n' \
-        b'SWpuTVMbvJukrWK9ScPFkUyBC7FpkZ/RJ6pwiE2nVHjcrysAmK2/KB1Hk/NmO+fw\n' \
-        b'evIcYXwrxNLm9k6XM5xyJcl7ZK3GInZbuEcH4NdRYnAo7dCLtuwRFUW4fgSRUjjx\n' \
-        b'FXGJLd830iDgHzM0VyTq77gzKpn5VEZbIvDWgc8oxKHsrJKbyv3UGeC0q04K2EQR\n' \
-        b'6tq71gbS/hv9QCxmR6ygNqq8bz0dsmZXeeYxAgMBAAEwDQYJKoZIhvcNAQELBQAD\n' \
-        b'ggEBAIPQnGGAlwbK+f4V7SUUjXnsO7oVlMtTO7JWAk+g8W9colUeMDHW/Ygcwu3e\n' \
-        b'OlX5NSEV1wcQxuqyNWbEgrsZourePdVWujc/9qSVfaU/BjOj2CLylAf6ZNj/XpL/\n' \
-        b'PNCSCLM40cbhw/SeiNZ9WxkuuHiC32QxmR4kyvvXcHEGqVA2cOVAvncstW4gGowi\n' \
-        b'ObNYddXOmoOf8d5oHcO5vlhYyfbmShuq1PLygzUhG2jS+5aX9gmDtv+LtVGdXXWV\n' \
-        b'zSCh3+H4NSUWs3P1pKDFIUT3jGLQ3UavIS5KCizfBUbltx6LBSgmBbHf89RsKBbT\n' \
-        b'rxaukysD4sNgVHKptTq0fJ+2CjM=\n' \
-        b'-----END CERTIFICATE-----\n'
-    return cert
+    return TEST_CERTIFICATE
 
 
 @pytest.fixture
@@ -150,31 +153,22 @@ def test_certificate_authorities():
     return json.dumps({
         'test': [
             {
-                'crt': test_certificate().decode('utf-8'),
-                'key': test_key_pair.export_to_pem(
-                    private_key=True,
-                    password=None
-                ).decode('utf-8'),
+                'crt': TEST_CERTIFICATE.decode('utf-8'),
+                'key': TEST_PRIVATE_KEY.decode('utf-8'),
                 'passphrase': None,
                 'kid': '0h7R8dL0rU-b3p3onft_BPfuRW1Ld7YjsFnOWJuFXUE',
             },
             {
-                'crt': test_certificate().decode('utf-8'),
-                'key': test_key_pair.export_to_pem(
-                    private_key=True,
-                    password=None
-                ).decode('utf-8'),
+                'crt': TEST_CERTIFICATE.decode('utf-8'),
+                'key': TEST_PRIVATE_KEY.decode('utf-8'),
                 'passphrase': None,
                 'kid': 'test-key',
             },
         ],
         'dummy': [
             {
-                'crt': test_certificate().decode('utf-8'),
-                'key': test_key_pair.export_to_pem(
-                    private_key=True,
-                    password=None
-                ).decode('utf-8'),
+                'crt': TEST_CERTIFICATE.decode('utf-8'),
+                'key': TEST_PRIVATE_KEY.decode('utf-8'),
                 'passphrase': None,
                 'kid': '0h7R8dL0rU-b3p3onft_BPfuRW1Ld7YjsFnOWJuFXUE',
             },

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import json
 import pytest
 
 from jwcrypto import jwk
@@ -142,3 +143,40 @@ def test_jwks():
              'RVxiS3fN9Ig4B8zNFck6u-4MyqZ-VRGWyLw1oHPKMSh7KySm8r91BngtKtOCt'
              'hEEerau9YG0v4b_UAsZkesoDaqvG89HbJmV3nmMQ'
     }
+
+
+@pytest.fixture
+def test_certificate_authorities():
+    return json.dumps({
+        'test': [
+            {
+                'crt': test_certificate().decode('utf-8'),
+                'key': test_key_pair.export_to_pem(
+                    private_key=True,
+                    password=None
+                ).decode('utf-8'),
+                'passphrase': None,
+                'kid': '0h7R8dL0rU-b3p3onft_BPfuRW1Ld7YjsFnOWJuFXUE',
+            },
+            {
+                'crt': test_certificate().decode('utf-8'),
+                'key': test_key_pair.export_to_pem(
+                    private_key=True,
+                    password=None
+                ).decode('utf-8'),
+                'passphrase': None,
+                'kid': 'test-key',
+            },
+        ],
+        'dummy': [
+            {
+                'crt': test_certificate().decode('utf-8'),
+                'key': test_key_pair.export_to_pem(
+                    private_key=True,
+                    password=None
+                ).decode('utf-8'),
+                'passphrase': None,
+                'kid': '0h7R8dL0rU-b3p3onft_BPfuRW1Ld7YjsFnOWJuFXUE',
+            },
+        ],
+    })

--- a/tests/unit/confidant/services/jwkmanager_test.py
+++ b/tests/unit/confidant/services/jwkmanager_test.py
@@ -185,9 +185,7 @@ def test_get_jwks_not_found(test_key_pair, test_jwk_payload,
               Mock(wraps=datetime.datetime))
 @patch.object(confidant.services.jwkmanager, 'ACTIVE_SIGNING_KEYS',
               {'test': '0h7R8dL0rU-b3p3onft_BPfuRW1Ld7YjsFnOWJuFXUE'})
-@patch('confidant.services.jwkmanager.jwk_manager')
-def test_get_jwt_with_ca(mock_jwk_manager, test_jwk_payload,
-                         test_jwt, test_certificate_authorities):
+def test_get_jwt_with_ca(test_jwk_payload, test_jwt, test_certificate_authorities):
     with patch.object(confidant.services.jwkmanager,
                       'CERTIFICATE_AUTHORITIES',
                       test_certificate_authorities):
@@ -201,8 +199,6 @@ def test_get_jwt_with_ca(mock_jwk_manager, test_jwk_payload,
                 second=0,
                 microsecond=0
             )
-        mock_jwk_manager.return_value = jwk_manager
-        result = mock_jwk_manager.get_jwt('test',
-                                          test_jwk_payload)
+        result = jwk_manager.get_jwt('test',
+                                     test_jwk_payload)
     assert result == test_jwt
-    mock_jwk_manager.get_active_key.assert_called_once_with('test')

--- a/tests/unit/confidant/services/jwkmanager_test.py
+++ b/tests/unit/confidant/services/jwkmanager_test.py
@@ -167,10 +167,10 @@ def test_get_jwks(test_key_pair, test_jwk_payload, test_jwt,
                   test_jwks):
     test_private_key = test_key_pair.export_to_pem(private_key=True,
                                                    password=None)
-    jwk_manager.set_key('test',
+    jwk_manager.set_key('testing',
                         '0h7R8dL0rU-b3p3onft_BPfuRW1Ld7YjsFnOWJuFXUE',
                         test_private_key.decode('utf-8'))
-    result = jwk_manager.get_jwks('test')
+    result = jwk_manager.get_jwks('testing')
     assert len(result) == 1
     assert result[0] == test_jwks
 

--- a/tests/unit/confidant/services/jwkmanager_test.py
+++ b/tests/unit/confidant/services/jwkmanager_test.py
@@ -201,6 +201,7 @@ def test_get_jwt_with_ca(mock_jwk_manager, test_jwk_payload,
                 second=0,
                 microsecond=0
             )
+        mock_jwk_manager.return_value = jwk_manager
         result = mock_jwk_manager.get_jwt('test',
                                           test_jwk_payload)
     assert result == test_jwt

--- a/tests/unit/confidant/services/jwkmanager_test.py
+++ b/tests/unit/confidant/services/jwkmanager_test.py
@@ -12,7 +12,9 @@ from calendar import timegm
 def test_set_key(test_key_pair):
     test_private_key = test_key_pair.export_to_pem(private_key=True,
                                                    password=None)
-    kid = jwk_manager.set_key('test', 'test-key', test_private_key.decode('utf-8'))
+    kid = jwk_manager.set_key('test',
+                              'test-key',
+                              test_private_key.decode('utf-8'))
     assert kid == 'test-key'
 
 
@@ -24,6 +26,8 @@ def test_set_key_encrypted(test_encrypted_key):
 
 @patch.object(confidant.services.jwkmanager, 'datetime',
               Mock(wraps=datetime.datetime))
+@patch.object(confidant.services.jwkmanager, 'ACTIVE_SIGNING_KEYS',
+              {'test': '0h7R8dL0rU-b3p3onft_BPfuRW1Ld7YjsFnOWJuFXUE'})
 def test_get_jwt(test_key_pair, test_jwk_payload, test_jwt):
     test_private_key = test_key_pair.export_to_pem(private_key=True,
                                                    password=None)
@@ -48,6 +52,8 @@ def test_get_jwt(test_key_pair, test_jwk_payload, test_jwt):
 @patch.object(confidant.services.jwkmanager, 'datetime',
               Mock(wraps=datetime.datetime))
 @patch.object(confidant.services.jwkmanager, 'JWT_CACHING_ENABLED', True)
+@patch.object(confidant.services.jwkmanager, 'ACTIVE_SIGNING_KEYS',
+              {'test': '0h7R8dL0rU-b3p3onft_BPfuRW1Ld7YjsFnOWJuFXUE'})
 def test_get_jwt_caches_jwt(test_key_pair, test_jwk_payload, test_jwt):
     test_private_key = test_key_pair.export_to_pem(private_key=True,
                                                    password=None)
@@ -86,6 +92,8 @@ def test_get_jwt_caches_jwt(test_key_pair, test_jwk_payload, test_jwt):
 @patch.object(confidant.services.jwkmanager, 'datetime',
               Mock(wraps=datetime.datetime))
 @patch.object(confidant.services.jwkmanager, 'JWT_CACHING_ENABLED', False)
+@patch.object(confidant.services.jwkmanager, 'ACTIVE_SIGNING_KEYS',
+              {'test': '0h7R8dL0rU-b3p3onft_BPfuRW1Ld7YjsFnOWJuFXUE'})
 def test_get_jwt_does_not_cache_jwt(test_key_pair, test_jwk_payload, test_jwt):
     test_private_key = test_key_pair.export_to_pem(private_key=True,
                                                    password=None)
@@ -100,6 +108,7 @@ def test_get_jwt_does_not_cache_jwt(test_key_pair, test_jwk_payload, test_jwt):
             microsecond=0
         )
     jwk_manager.set_key('test',
+                        test_key_pair.thumbprint(),
                         test_private_key.decode('utf-8'))
     result = jwk_manager.get_jwt('test',
                                  test_jwk_payload)
@@ -123,8 +132,8 @@ def test_get_jwt_does_not_cache_jwt(test_key_pair, test_jwk_payload, test_jwt):
 def test_get_jwt_raises_no_key_id(test_key_pair, test_jwk_payload):
     test_private_key = test_key_pair.export_to_pem(private_key=True,
                                                    password=None)
-    jwk_manager.set_key('test-key', test_private_key.decode('utf-8'))
-    with pytest.raises(ValueError, match='This private key is not stored'):
+    jwk_manager.set_key('test', 'test-key', test_private_key.decode('utf-8'))
+    with pytest.raises(ValueError, match='No active key for this environment'):
         jwk_manager.get_jwt('non-existent', test_jwk_payload)
 
 

--- a/tests/unit/confidant/services/jwkmanager_test.py
+++ b/tests/unit/confidant/services/jwkmanager_test.py
@@ -167,8 +167,10 @@ def test_get_jwks(test_key_pair, test_jwk_payload, test_jwt,
                   test_jwks):
     test_private_key = test_key_pair.export_to_pem(private_key=True,
                                                    password=None)
-    jwk_manager.set_key('test', 'test-key', test_private_key.decode('utf-8'))
-    result = jwk_manager.get_jwks('test')
+    jwk_manager.set_key('testing',
+                        '0h7R8dL0rU-b3p3onft_BPfuRW1Ld7YjsFnOWJuFXUE',
+                        test_private_key.decode('utf-8'))
+    result = jwk_manager.get_jwks('testing')
     assert len(result) == 1
     assert result[0] == test_jwks
 

--- a/tests/unit/confidant/services/jwkmanager_test.py
+++ b/tests/unit/confidant/services/jwkmanager_test.py
@@ -185,7 +185,8 @@ def test_get_jwks_not_found(test_key_pair, test_jwk_payload,
               Mock(wraps=datetime.datetime))
 @patch.object(confidant.services.jwkmanager, 'ACTIVE_SIGNING_KEYS',
               {'test': '0h7R8dL0rU-b3p3onft_BPfuRW1Ld7YjsFnOWJuFXUE'})
-def test_get_jwt(test_key_pair, test_jwk_payload, test_jwt, test_certificate_authorities):
+def test_get_jwt(test_key_pair, test_jwk_payload,
+                 test_jwt, test_certificate_authorities):
     test_private_key = test_key_pair.export_to_pem(private_key=True,
                                                    password=None)
     with patch.object(confidant.services.jwkmanager,
@@ -203,9 +204,9 @@ def test_get_jwt(test_key_pair, test_jwk_payload, test_jwt, test_certificate_aut
             )
         result = jwk_manager.get_jwt('test',
                                      test_jwk_payload)
-        assert result == test_jwt
-        jwk_manager.set_key.assert_called_with(
-            'test',
-            test_key_pair.thumbprint(),
-            test_private_key.decode('utf-8')
-        )
+    assert result == test_jwt
+    jwk_manager.set_key.assert_called_with(
+        'test',
+        test_key_pair.thumbprint(),
+        test_private_key.decode('utf-8')
+    )

--- a/tests/unit/confidant/services/jwkmanager_test.py
+++ b/tests/unit/confidant/services/jwkmanager_test.py
@@ -167,10 +167,10 @@ def test_get_jwks(test_key_pair, test_jwk_payload, test_jwt,
                   test_jwks):
     test_private_key = test_key_pair.export_to_pem(private_key=True,
                                                    password=None)
-    jwk_manager.set_key('testing',
+    jwk_manager.set_key('test',
                         '0h7R8dL0rU-b3p3onft_BPfuRW1Ld7YjsFnOWJuFXUE',
                         test_private_key.decode('utf-8'))
-    result = jwk_manager.get_jwks('testing')
+    result = jwk_manager.get_jwks('test')
     assert len(result) == 1
     assert result[0] == test_jwks
 

--- a/tests/unit/confidant/services/jwkmanager_test.py
+++ b/tests/unit/confidant/services/jwkmanager_test.py
@@ -12,12 +12,12 @@ from calendar import timegm
 def test_set_key(test_key_pair):
     test_private_key = test_key_pair.export_to_pem(private_key=True,
                                                    password=None)
-    kid = jwk_manager.set_key('test-key', test_private_key.decode('utf-8'))
+    kid = jwk_manager.set_key('test', 'test-key', test_private_key.decode('utf-8'))
     assert kid == 'test-key'
 
 
 def test_set_key_encrypted(test_encrypted_key):
-    kid = jwk_manager.set_key('test-key', test_encrypted_key,
+    kid = jwk_manager.set_key('test', 'test-key', test_encrypted_key,
                               passphrase='123456')
     assert kid == 'test-key'
 
@@ -37,9 +37,10 @@ def test_get_jwt(test_key_pair, test_jwk_payload, test_jwt):
             second=0,
             microsecond=0
         )
-    jwk_manager.set_key(test_key_pair.thumbprint(),
+    jwk_manager.set_key('test',
+                        test_key_pair.thumbprint(),
                         test_private_key.decode('utf-8'))
-    result = jwk_manager.get_jwt(test_key_pair.thumbprint(),
+    result = jwk_manager.get_jwt('test',
                                  test_jwk_payload)
     assert result == test_jwt
 
@@ -60,9 +61,10 @@ def test_get_jwt_caches_jwt(test_key_pair, test_jwk_payload, test_jwt):
             second=0,
             microsecond=0
         )
-    jwk_manager.set_key(test_key_pair.thumbprint(),
+    jwk_manager.set_key('test',
+                        test_key_pair.thumbprint(),
                         test_private_key.decode('utf-8'))
-    result = jwk_manager.get_jwt(test_key_pair.thumbprint(),
+    result = jwk_manager.get_jwt('test',
                                  test_jwk_payload)
 
     confidant.services.jwkmanager.datetime.now.return_value = \
@@ -75,7 +77,7 @@ def test_get_jwt_caches_jwt(test_key_pair, test_jwk_payload, test_jwt):
             second=0,
             microsecond=0
         )
-    cached_result = jwk_manager.get_jwt(test_key_pair.thumbprint(),
+    cached_result = jwk_manager.get_jwt('test',
                                         test_jwk_payload)
     assert result == test_jwt
     assert result == cached_result
@@ -97,9 +99,9 @@ def test_get_jwt_does_not_cache_jwt(test_key_pair, test_jwk_payload, test_jwt):
             second=0,
             microsecond=0
         )
-    jwk_manager.set_key(test_key_pair.thumbprint(),
+    jwk_manager.set_key('test',
                         test_private_key.decode('utf-8'))
-    result = jwk_manager.get_jwt(test_key_pair.thumbprint(),
+    result = jwk_manager.get_jwt('test',
                                  test_jwk_payload)
 
     confidant.services.jwkmanager.datetime.now.return_value = \
@@ -112,7 +114,7 @@ def test_get_jwt_does_not_cache_jwt(test_key_pair, test_jwk_payload, test_jwt):
             second=1,
             microsecond=0
         )
-    not_cached_result = jwk_manager.get_jwt(test_key_pair.thumbprint(),
+    not_cached_result = jwk_manager.get_jwt('test',
                                             test_jwk_payload)
     assert result == test_jwt
     assert result != not_cached_result
@@ -131,7 +133,7 @@ def test_get_payload(mock_validate, test_key_pair, test_jwk_payload, test_jwt,
                      test_certificate):
     test_private_key = test_key_pair.export_to_pem(private_key=True,
                                                    password=None)
-    jwk_manager.set_key('test-key', test_private_key.decode('utf-8'))
+    jwk_manager.set_key('test', 'test-key', test_private_key.decode('utf-8'))
     result = jwk_manager.get_payload(test_certificate.decode('utf-8'),
                                      test_jwt)
     mocked_date = datetime.datetime(
@@ -156,9 +158,9 @@ def test_get_jwks(test_key_pair, test_jwk_payload, test_jwt,
                   test_jwks):
     test_private_key = test_key_pair.export_to_pem(private_key=True,
                                                    password=None)
-    jwk_manager.set_key('test-key', test_private_key.decode('utf-8'))
-    result = jwk_manager.get_jwks('test-key')
-    assert result == test_jwks
+    jwk_manager.set_key('test', 'test-key', test_private_key.decode('utf-8'))
+    result = jwk_manager.get_jwks('test')
+    assert result == [test_jwks]
 
 
 def test_get_jwks_not_found(test_key_pair, test_jwk_payload,

--- a/tests/unit/confidant/services/jwkmanager_test.py
+++ b/tests/unit/confidant/services/jwkmanager_test.py
@@ -185,10 +185,8 @@ def test_get_jwks_not_found(test_key_pair, test_jwk_payload,
               Mock(wraps=datetime.datetime))
 @patch.object(confidant.services.jwkmanager, 'ACTIVE_SIGNING_KEYS',
               {'test': '0h7R8dL0rU-b3p3onft_BPfuRW1Ld7YjsFnOWJuFXUE'})
-def test_get_jwt(test_key_pair, test_jwk_payload,
-                 test_jwt, test_certificate_authorities):
-    test_private_key = test_key_pair.export_to_pem(private_key=True,
-                                                   password=None)
+def test_get_jwt_with_ca(test_jwk_payload, test_jwt,
+                         test_certificate_authorities):
     with patch.object(confidant.services.jwkmanager,
                       'CERTIFICATE_AUTHORITIES',
                       test_certificate_authorities):
@@ -205,8 +203,4 @@ def test_get_jwt(test_key_pair, test_jwk_payload,
         result = jwk_manager.get_jwt('test',
                                      test_jwk_payload)
     assert result == test_jwt
-    jwk_manager.set_key.assert_called_with(
-        'test',
-        test_key_pair.thumbprint(),
-        test_private_key.decode('utf-8')
-    )
+    jwk_manager.get_active_key.assert_called_once_with('test')

--- a/tests/unit/confidant/services/jwkmanager_test.py
+++ b/tests/unit/confidant/services/jwkmanager_test.py
@@ -185,7 +185,8 @@ def test_get_jwks_not_found(test_key_pair, test_jwk_payload,
               Mock(wraps=datetime.datetime))
 @patch.object(confidant.services.jwkmanager, 'ACTIVE_SIGNING_KEYS',
               {'test': '0h7R8dL0rU-b3p3onft_BPfuRW1Ld7YjsFnOWJuFXUE'})
-def test_get_jwt_with_ca(test_jwk_payload, test_jwt, test_certificate_authorities):
+def test_get_jwt_with_ca(test_jwk_payload, test_jwt,
+                         test_certificate_authorities):
     with patch.object(confidant.services.jwkmanager,
                       'CERTIFICATE_AUTHORITIES',
                       test_certificate_authorities):

--- a/tests/unit/confidant/services/jwkmanager_test.py
+++ b/tests/unit/confidant/services/jwkmanager_test.py
@@ -186,8 +186,8 @@ def test_get_jwks_not_found(test_key_pair, test_jwk_payload,
 @patch.object(confidant.services.jwkmanager, 'ACTIVE_SIGNING_KEYS',
               {'test': '0h7R8dL0rU-b3p3onft_BPfuRW1Ld7YjsFnOWJuFXUE'})
 @patch('confidant.services.jwkmanager.jwk_manager')
-def test_get_jwt_with_ca(test_jwk_payload, test_jwt,
-                         test_certificate_authorities, mock_jwk_manager):
+def test_get_jwt_with_ca(mock_jwk_manager, test_jwk_payload,
+                         test_jwt, test_certificate_authorities):
     with patch.object(confidant.services.jwkmanager,
                       'CERTIFICATE_AUTHORITIES',
                       test_certificate_authorities):
@@ -202,6 +202,6 @@ def test_get_jwt_with_ca(test_jwk_payload, test_jwt,
                 microsecond=0
             )
         result = mock_jwk_manager.get_jwt('test',
-                                        test_jwk_payload)
+                                          test_jwk_payload)
     assert result == test_jwt
     mock_jwk_manager.get_active_key.assert_called_once_with('test')

--- a/tests/unit/confidant/services/jwkmanager_test.py
+++ b/tests/unit/confidant/services/jwkmanager_test.py
@@ -169,7 +169,8 @@ def test_get_jwks(test_key_pair, test_jwk_payload, test_jwt,
                                                    password=None)
     jwk_manager.set_key('test', 'test-key', test_private_key.decode('utf-8'))
     result = jwk_manager.get_jwks('test')
-    assert result == [test_jwks]
+    assert len(result) == 1
+    assert result[0] == test_jwks
 
 
 def test_get_jwks_not_found(test_key_pair, test_jwk_payload,

--- a/tests/unit/confidant/services/jwkmanager_test.py
+++ b/tests/unit/confidant/services/jwkmanager_test.py
@@ -185,8 +185,9 @@ def test_get_jwks_not_found(test_key_pair, test_jwk_payload,
               Mock(wraps=datetime.datetime))
 @patch.object(confidant.services.jwkmanager, 'ACTIVE_SIGNING_KEYS',
               {'test': '0h7R8dL0rU-b3p3onft_BPfuRW1Ld7YjsFnOWJuFXUE'})
+@patch('confidant.services.jwkmanager.jwk_manager')
 def test_get_jwt_with_ca(test_jwk_payload, test_jwt,
-                         test_certificate_authorities):
+                         test_certificate_authorities, mock_jwk_manager):
     with patch.object(confidant.services.jwkmanager,
                       'CERTIFICATE_AUTHORITIES',
                       test_certificate_authorities):
@@ -200,7 +201,7 @@ def test_get_jwt_with_ca(test_jwk_payload, test_jwt,
                 second=0,
                 microsecond=0
             )
-        result = jwk_manager.get_jwt('test',
-                                     test_jwk_payload)
+        result = mock_jwk_manager.get_jwt('test',
+                                        test_jwk_payload)
     assert result == test_jwt
-    jwk_manager.get_active_key.assert_called_once_with('test')
+    mock_jwk_manager.get_active_key.assert_called_once_with('test')


### PR DESCRIPTION
- Supports new format for CERTIFICATE_AUTHORITIES where `name` is environment (and multiple keys can be added):
  ```
  [
  {
    'key': redacted,
    'crt': redacted,
    'name': 'staging',
    'passphrase': redacted, 
    'kid': 'staging_slot_a'
  }, ...
  ]
  ```
- Signing key must be activated for each environment as `ACTIVE_SIGNING_KEYS={"staging": "some_kid", "production": "some_kid"}`, otherwise endpoint will return 400. This will be the key used to sign tokens.
- Public JWKS will expose all keys per environment.