### PR TITLE
Add kwargs to JWT fetch

### DIFF
--- a/confidant/routes/jwks.py
+++ b/confidant/routes/jwks.py
@@ -37,7 +37,7 @@ def get_token(id):
        {
          "is_service": true,
          "requester": "pyexample2",
-         "token": "ey..."
+         "user": "ey..."
        }
 
     :resheader Content-Type: application/json

--- a/confidant/routes/jwks.py
+++ b/confidant/routes/jwks.py
@@ -35,9 +35,7 @@ def get_token(id):
        Content-Type: application/json
 
        {
-         "is_service": true,
-         "requester": "pyexample2",
-         "user": "ey..."
+         "token": "ey..."
        }
 
     :resheader Content-Type: application/json

--- a/confidant/routes/jwks.py
+++ b/confidant/routes/jwks.py
@@ -25,7 +25,7 @@ def get_token(id):
 
     .. sourcecode:: http
 
-       GET /v1/jwks/token/some-username
+       GET /v1/jwks/token/some-id
 
     **Example response**:
 
@@ -35,6 +35,8 @@ def get_token(id):
        Content-Type: application/json
 
        {
+         "is_service": true,
+         "requester": "pyexample2",
          "token": "ey..."
        }
 
@@ -42,20 +44,27 @@ def get_token(id):
     :statuscode 200: Success
     :statuscode 400: JWTs are not supported for this user
     """
-    parent = authnz.get_logged_in_user()
+    logged_in_user = authnz.get_logged_in_user()
     environment = request.args.get('environment', type=str)
 
     if not environment:
         return jsonify({'error': 'Please specify an environment'}), 400
 
-    if not acl_module_check(resource_type='jwt', action='get', resource_id=id):
-        msg = f'{parent} does not have access to get JWT {id}'
+    if not acl_module_check(
+        resource_type='jwt',
+        action='get',
+        resource_id=logged_in_user,
+        kwargs={
+            'id': id,
+        }
+    ):
+        msg = f'{logged_in_user} does not have access to get JWT {id}'
         error_msg = {'error': msg}
         return jsonify(error_msg), 403
 
     payload = {
-        'is_service': authnz.user_is_service(parent),
-        'parent': parent,
+        'is_service': authnz.user_is_service(logged_in_user),
+        'requester': logged_in_user,
         'user': id,
     }
 

--- a/confidant/services/jwkmanager.py
+++ b/confidant/services/jwkmanager.py
@@ -83,25 +83,25 @@ class JWKManager:
         if 'user' not in payload:
             raise ValueError('Please include the user in the payload')
 
-        if 'parent' not in payload:
-            raise ValueError('Please include the parent in the payload')
+        if 'requester' not in payload:
+            raise ValueError('Please include the requester in the payload')
 
         user = payload['user']
-        parent = payload['parent']
+        requester = payload['requester']
         if kid not in self._token_cache:
             self._token_cache[kid] = {}
 
-        if parent not in self._token_cache[kid]:
-            self._token_cache[kid][parent] = {}
+        if requester not in self._token_cache[kid]:
+            self._token_cache[kid][requester] = {}
 
         now = datetime.now(tz=timezone.utc)
 
         # return token from cache
-        if user in self._token_cache[kid][parent].keys() \
+        if user in self._token_cache[kid][requester].keys() \
                 and JWT_CACHING_ENABLED:
-            if now < self._token_cache[kid][parent][user]['expiry']:
+            if now < self._token_cache[kid][requester][user]['expiry']:
                 stats.incr('get_jwt.cache.hit')
-                return self._token_cache[kid][parent][user]['token']
+                return self._token_cache[kid][requester][user]['token']
 
         # cache miss, generate new token and update cache
         expiry = now + timedelta(seconds=expiration_seconds)
@@ -119,7 +119,7 @@ class JWKManager:
                 algorithm=algorithm,
             )
 
-        self._token_cache[kid][parent][user] = {
+        self._token_cache[kid][requester][user] = {
             'expiry': expiry,
             'token': token
         }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -111,21 +111,21 @@ def test_key_pair():
 
 @pytest.fixture
 def test_jwk_payload():
-    return {'user': 'test', 'parent': 'test-parent', 'is_service': True}
+    return {'user': 'test', 'requester': 'test-parent', 'is_service': True}
 
 
 @pytest.fixture
 def test_jwt():
-    return 'eyJhbGciOiJSUzI1NiIsImtpZCI6IjBoN1I4ZEwwclUtYjNwM29uZnRfQlBmdVJX' \
-           'MUxkN1lqc0ZuT1dKdUZYVUUiLCJ0eXAiOiJKV1QifQ.eyJ1c2VyIjoidGVzdCIsI' \
-           'nBhcmVudCI6InRlc3QtcGFyZW50IiwiaXNfc2VydmljZSI6dHJ1ZSwiaWF0IjoxN' \
-           'jAyMjg4MDAwLCJuYmYiOjE2MDIyODgwMDAsImV4cCI6MTYwMjI5MTYwMH0.rErhD' \
-           'Vt65HJ39WdFBnx69ig0ETCZoD8_Xpgtqs-APMCB-eRDsNj3bn_6B4HMr0E4bBf70' \
-           '4_uvy6Jp-WzPj4v7ybuRkQdVS6IC9pnbXcc0DPzyYh0JyOaBiE8Dj4HdVEf91N7d' \
-           '8ZWgQnhfsFuVIs8PC4t_fX2CoC27dOgIGyCSVy5BaOx4co72-vpUIWtQseBhxGT0' \
-           'hECk6LzORAXujypbCp7tBQ75yEqjxjZBA26JWQcUUS9ic_ug1oYzMAdFkpjK86nF' \
-           'oN1WTIoV80TGRbIaLdx5Tazwz5WRXcYK-5h8NMr5nEl2KKxjrVB693NphcqjgUpA' \
-           'L13mErNRSt9Zh7Uow'
+    return 'eyJhbGciOiJSUzI1NiIsImtpZCI6IjBoN1I4ZEwwclUtYjNwM29uZnRfQlBmdVJXM' \
+           'UxkN1lqc0ZuT1dKdUZYVUUiLCJ0eXAiOiJKV1QifQ.eyJ1c2VyIjoidGVzdCIsInJ' \
+           'lcXVlc3RlciI6InRlc3QtcGFyZW50IiwiaXNfc2VydmljZSI6dHJ1ZSwiaWF0Ijox' \
+           'NjAyMjg4MDAwLCJuYmYiOjE2MDIyODgwMDAsImV4cCI6MTYwMjI5MTYwMH0.JfjzY' \
+           '0_mVG4JdJl75pNlfRf3lVHw8qfwJbXmWeIxAIxrc1No-v5ZRamXeqZYQtjriKJPmC' \
+           'Fx8TZgACtsLP0A2nHvqLQZ711oKfeOVASCJU2F3ya4oDV3p2y_eVfJOB-wNWaqEMi' \
+           'dTFnk8xkmCGOO0HeXZ4h2KMlWZmyJwgwx1K8XMrW-IjUX3h4mz4AHm5LykSHatNoI' \
+           'C8aZx2lZ4Recdr0PD8Z-UzC68G14uNxHqepEi-FVaOJ6jEYeXAgOq-7nu7kFsMRHl' \
+           'UoHy4l1VxEUbI3BO4cUmTBD7lE4-JJq-IPoFqkiXCF-Iw90Zbx8T5KQIkt76idlup' \
+           'yz_O0wqGv9mA'
 
 
 @pytest.fixture

--- a/tests/unit/confidant/routes/jwks_test.py
+++ b/tests/unit/confidant/routes/jwks_test.py
@@ -16,7 +16,7 @@ def test_get_token_override_user(mocker):
     mock_get_jwt.assert_called_with('test', {
         'user': 'test-override',
         'is_service': True,
-        'parent': 'test',
+        'requester': 'test',
     })
     assert ret.status_code == 200
 


### PR DESCRIPTION
We need two parameters in the JWT RBAC check: the logged in user AND the requested JWT id.

Minor variable naming changes.