### PR TITLE
Pass in environment to jwt kwargs

### DIFF
--- a/confidant/routes/jwks.py
+++ b/confidant/routes/jwks.py
@@ -58,6 +58,7 @@ def get_token(id):
         resource_id=logged_in_user,
         kwargs={
             'id': id,
+            'environment': environment,
         }
     ):
         msg = f'{logged_in_user} does not have access to get JWT {id}'


### PR DESCRIPTION
Allow RBAC decisions based on environment.  

Example: Prevents staging from minting prod tokens and vice versa.