### PR TITLE
Remove duplicate markupsafe from docs/requirements.txt

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,7 +1,6 @@
 -r ../requirements.txt
 GitPython==2.0.8
 Jinja2==2.11.3
-MarkupSafe==1.1.1
 Pygments==2.7.4
 alabaster==0.7.10
 babel==2.9.1


### PR DESCRIPTION
`MarkupSafe` is already pulled in from `../requirements.txt` so no need to explicitly include in `docs/requirements.txt`