### PR TITLE
Use ubuntu-20.04 for GH actions

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,7 +1,7 @@
 on: pull_request
 jobs:
   pre-commit:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v1
@@ -15,7 +15,7 @@ jobs:
         run: pre-commit run --all-files
   ## Uncomment once license tests are in and passing
   #license-check:
-  #  runs-on: ubuntu-18.04
+  #  runs-on: ubuntu-20.04
   #  steps:
   #    - name: Checkout
   #      uses: actions/checkout@v1
@@ -36,7 +36,7 @@ jobs:
   #    - name: Run license finder
   #      run: license_finder
   test-unit:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
         matrix:
           python-version: ['3.7.x', '3.8.x']
@@ -54,14 +54,14 @@ jobs:
       - name: Run python unit tests
         run: make test_unit
   test-integration:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v1
       - name: Run python integration tests
         run: "make actions_test_integration"
   test-frontend:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v1

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build-and-deploy-docs:
     name: Build and publish docs
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v1
@@ -33,7 +33,7 @@ jobs:
           FOLDER: generated/docs # The folder the action should deploy.
   build-and-publish-python-module:
     name: Build and publish python module to pypi
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v1
@@ -53,7 +53,7 @@ jobs:
           password: ${{ secrets.pypi_password }}
   build-and-publish-docker-image:
     name: Build and publish docker image
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v1

--- a/requirements.txt
+++ b/requirements.txt
@@ -181,7 +181,7 @@ werkzeug==1.0.1
     # via flask
 wrapt==1.14.1
     # via deprecated
-xmlsec==1.3.3
+xmlsec==1.3.10
     # via python3-saml
 zope-event==4.5.0
     # via gevent


### PR DESCRIPTION
Switch to ubuntu-20.04 since ubuntu-18.04 is deprecated and going away soon
https://github.com/actions/runner-images/issues/6002
