### PR TITLE
Prefix JWT settings with JWT_ , add JWT_IS_CA_ENCRYPTED setting

### DIFF
--- a/confidant/services/jwkmanager.py
+++ b/confidant/services/jwkmanager.py
@@ -4,10 +4,10 @@ import jwt
 from jwcrypto import jwk
 from typing import Dict, Optional, List, Tuple
 
+from confidant.settings import JWT_ACTIVE_SIGNING_KEYS
+from confidant.settings import JWT_CACHING_ENABLED
 from confidant.settings import JWT_CERTIFICATE_AUTHORITIES
 from confidant.settings import JWT_DEFAULT_JWT_EXPIRATION_SECONDS
-from confidant.settings import JWT_CACHING_ENABLED
-from confidant.settings import JWT_ACTIVE_SIGNING_KEYS
 from confidant.utils import stats
 from datetime import datetime, timezone, timedelta
 from cerberus import Validator

--- a/confidant/services/jwkmanager.py
+++ b/confidant/services/jwkmanager.py
@@ -4,8 +4,10 @@ import jwt
 from jwcrypto import jwk
 from typing import Dict, Optional, List, Tuple
 
-from confidant.settings import JWT_CERTIFICATE_AUTHORITIES, \
-    JWT_DEFAULT_JWT_EXPIRATION_SECONDS, JWT_CACHING_ENABLED, JWT_ACTIVE_SIGNING_KEYS
+from confidant.settings import JWT_CERTIFICATE_AUTHORITIES
+from confidant.settings import JWT_DEFAULT_JWT_EXPIRATION_SECONDS
+from confidant.settings import JWT_CACHING_ENABLED
+from confidant.settings import JWT_ACTIVE_SIGNING_KEYS
 from confidant.utils import stats
 from datetime import datetime, timezone, timedelta
 from cerberus import Validator

--- a/confidant/services/jwkmanager.py
+++ b/confidant/services/jwkmanager.py
@@ -4,8 +4,8 @@ import jwt
 from jwcrypto import jwk
 from typing import Dict, Optional, List, Tuple
 
-from confidant.settings import PKI_CERTIFICATE_AUTHORITIES, \
-    PKI_DEFAULT_JWT_EXPIRATION_SECONDS, PKI_JWT_CACHING_ENABLED, PKI_ACTIVE_SIGNING_KEYS
+from confidant.settings import JWT_CERTIFICATE_AUTHORITIES, \
+    JWT_DEFAULT_JWT_EXPIRATION_SECONDS, JWT_CACHING_ENABLED, JWT_ACTIVE_SIGNING_KEYS
 from confidant.utils import stats
 from datetime import datetime, timezone, timedelta
 from cerberus import Validator
@@ -31,9 +31,9 @@ class JWKManager:
 
     def _load_certificate_authorities(self) -> None:
         validator = Validator(CA_SCHEMA)
-        if PKI_CERTIFICATE_AUTHORITIES:
-            for environment in PKI_CERTIFICATE_AUTHORITIES:
-                for ca in PKI_CERTIFICATE_AUTHORITIES[environment]:
+        if JWT_CERTIFICATE_AUTHORITIES:
+            for environment in JWT_CERTIFICATE_AUTHORITIES:
+                for ca in JWT_CERTIFICATE_AUTHORITIES[environment]:
                     if validator.validate(ca):
                         self.set_key(environment, ca['kid'], ca['key'],
                                      passphrase=ca['passphrase'])
@@ -74,7 +74,7 @@ class JWKManager:
         return self._pem_cache[environment][kid]
 
     def get_jwt(self, environment: str, payload: dict,
-                expiration_seconds: int = PKI_DEFAULT_JWT_EXPIRATION_SECONDS,
+                expiration_seconds: int = JWT_DEFAULT_JWT_EXPIRATION_SECONDS,
                 algorithm: str = 'RS256') -> str:
         kid, key = self.get_active_key(environment)
         if not key:
@@ -98,7 +98,7 @@ class JWKManager:
 
         # return token from cache
         if user in self._token_cache[kid][requester].keys() \
-                and PKI_JWT_CACHING_ENABLED:
+                and JWT_CACHING_ENABLED:
             if now < self._token_cache[kid][requester][user]['expiry']:
                 stats.incr('get_jwt.cache.hit')
                 return self._token_cache[kid][requester][user]['token']
@@ -127,9 +127,9 @@ class JWKManager:
         return token
 
     def get_active_key(self, environment: str) -> Tuple[str, Optional[jwk.JWK]]:
-        if environment in PKI_ACTIVE_SIGNING_KEYS and environment in self._keys:
-            return PKI_ACTIVE_SIGNING_KEYS[environment], self._get_key(
-                PKI_ACTIVE_SIGNING_KEYS[environment],
+        if environment in JWT_ACTIVE_SIGNING_KEYS and environment in self._keys:
+            return JWT_ACTIVE_SIGNING_KEYS[environment], self._get_key(
+                JWT_ACTIVE_SIGNING_KEYS[environment],
                 environment
             )
         return '', None

--- a/confidant/settings.py
+++ b/confidant/settings.py
@@ -618,7 +618,7 @@ ENABLE_SAVE_LAST_DECRYPTION_TIME = bool_env('ENABLE_SAVE_LAST_DECRYPTION_TIME')
 # }, ...
 # ]
 
-if bool_env("PKI_IS_CA_ENCRYPTED", True):
+if bool_env("JWT_IS_CA_ENCRYPTED", True):
     decrypted_cas = encrypted_settings.decrypted_secrets.get(
         'JWT_CERTIFICATE_AUTHORITIES'
     )
@@ -628,7 +628,7 @@ else:
 JWT_CERTIFICATE_AUTHORITIES = json.loads(b64decode(decrypted_cas)) \
     if decrypted_cas else {}
 
-JWT_CACHING_ENABLED = bool_env('PKI_JWT_CACHING_ENABLED', False)
+JWT_CACHING_ENABLED = bool_env('JWT_CACHING_ENABLED', False)
 
 # Configuration validation
 _settings_failures = False

--- a/confidant/settings.py
+++ b/confidant/settings.py
@@ -617,13 +617,18 @@ ENABLE_SAVE_LAST_DECRYPTION_TIME = bool_env('ENABLE_SAVE_LAST_DECRYPTION_TIME')
 #   "kid": "some-kid"
 # }, ...
 # ]
-decrypted_cas = encrypted_settings.decrypted_secrets.get(
-    'CERTIFICATE_AUTHORITIES'
-)
-CERTIFICATE_AUTHORITIES = json.loads(b64decode(decrypted_cas)) \
+
+if bool_env("PKI_IS_CA_ENCRYPTED", True):
+    decrypted_cas = encrypted_settings.decrypted_secrets.get(
+        'PKI_CERTIFICATE_AUTHORITIES'
+    )
+else:
+    decrypted_cas = str_env('PKI_CERTIFICATE_AUTHORITIES')
+
+PKI_CERTIFICATE_AUTHORITIES = json.loads(b64decode(decrypted_cas)) \
     if decrypted_cas else {}
 
-JWT_CACHING_ENABLED = bool_env('JWT_CACHING_ENABLED', False)
+PKI_JWT_CACHING_ENABLED = bool_env('PKI_JWT_CACHING_ENABLED', False)
 
 # Configuration validation
 _settings_failures = False
@@ -646,9 +651,9 @@ def get(name, default=None):
 
 # Module that will perform an external ACL check on API endpoints
 ACL_MODULE = str_env('ACL_MODULE', 'confidant.authnz.rbac:default_acl')
-DEFAULT_JWT_EXPIRATION_SECONDS = int_env('DEFAULT_JWT_EXPIRATION_SECONDS', 3600)
+PKI_DEFAULT_JWT_EXPIRATION_SECONDS = int_env('DEFAULT_JWT_EXPIRATION_SECONDS', 3600)
 
 # Key IDs from CERTIFICATE_AUTHORITIES that should be used to sign new JWTs,
 # provide a JSON with the following format:
 # {"staging": "some_kid", "production": "some_kid"}
-ACTIVE_SIGNING_KEYS = json.loads(str_env('ACTIVE_SIGNING_KEYS', '{}'))
+PKI_ACTIVE_SIGNING_KEYS = json.loads(str_env('PKI_ACTIVE_SIGNING_KEYS', '{}'))

--- a/confidant/settings.py
+++ b/confidant/settings.py
@@ -620,15 +620,15 @@ ENABLE_SAVE_LAST_DECRYPTION_TIME = bool_env('ENABLE_SAVE_LAST_DECRYPTION_TIME')
 
 if bool_env("PKI_IS_CA_ENCRYPTED", True):
     decrypted_cas = encrypted_settings.decrypted_secrets.get(
-        'PKI_CERTIFICATE_AUTHORITIES'
+        'JWT_CERTIFICATE_AUTHORITIES'
     )
 else:
-    decrypted_cas = str_env('PKI_CERTIFICATE_AUTHORITIES')
+    decrypted_cas = str_env('JWT_CERTIFICATE_AUTHORITIES')
 
-PKI_CERTIFICATE_AUTHORITIES = json.loads(b64decode(decrypted_cas)) \
+JWT_CERTIFICATE_AUTHORITIES = json.loads(b64decode(decrypted_cas)) \
     if decrypted_cas else {}
 
-PKI_JWT_CACHING_ENABLED = bool_env('PKI_JWT_CACHING_ENABLED', False)
+JWT_CACHING_ENABLED = bool_env('PKI_JWT_CACHING_ENABLED', False)
 
 # Configuration validation
 _settings_failures = False
@@ -651,9 +651,9 @@ def get(name, default=None):
 
 # Module that will perform an external ACL check on API endpoints
 ACL_MODULE = str_env('ACL_MODULE', 'confidant.authnz.rbac:default_acl')
-PKI_DEFAULT_JWT_EXPIRATION_SECONDS = int_env('DEFAULT_JWT_EXPIRATION_SECONDS', 3600)
+JWT_DEFAULT_JWT_EXPIRATION_SECONDS = int_env('DEFAULT_JWT_EXPIRATION_SECONDS', 3600)
 
 # Key IDs from CERTIFICATE_AUTHORITIES that should be used to sign new JWTs,
 # provide a JSON with the following format:
 # {"staging": "some_kid", "production": "some_kid"}
-PKI_ACTIVE_SIGNING_KEYS = json.loads(str_env('PKI_ACTIVE_SIGNING_KEYS', '{}'))
+JWT_ACTIVE_SIGNING_KEYS = json.loads(str_env('PKI_ACTIVE_SIGNING_KEYS', '{}'))

--- a/confidant/settings.py
+++ b/confidant/settings.py
@@ -651,9 +651,11 @@ def get(name, default=None):
 
 # Module that will perform an external ACL check on API endpoints
 ACL_MODULE = str_env('ACL_MODULE', 'confidant.authnz.rbac:default_acl')
-JWT_DEFAULT_JWT_EXPIRATION_SECONDS = int_env('DEFAULT_JWT_EXPIRATION_SECONDS', 3600)
+JWT_DEFAULT_JWT_EXPIRATION_SECONDS = int_env(
+    'JWT_DEFAULT_JWT_EXPIRATION_SECONDS', 3600
+)
 
 # Key IDs from CERTIFICATE_AUTHORITIES that should be used to sign new JWTs,
 # provide a JSON with the following format:
 # {"staging": "some_kid", "production": "some_kid"}
-JWT_ACTIVE_SIGNING_KEYS = json.loads(str_env('PKI_ACTIVE_SIGNING_KEYS', '{}'))
+JWT_ACTIVE_SIGNING_KEYS = json.loads(str_env('JWT_ACTIVE_SIGNING_KEYS', '{}'))

--- a/tests/unit/confidant/services/jwkmanager_test.py
+++ b/tests/unit/confidant/services/jwkmanager_test.py
@@ -25,7 +25,7 @@ def test_set_key_encrypted(test_encrypted_key):
 
 @patch.object(confidant.services.jwkmanager, 'datetime',
               Mock(wraps=datetime.datetime))
-@patch.object(confidant.services.jwkmanager, 'ACTIVE_SIGNING_KEYS',
+@patch.object(confidant.services.jwkmanager, 'JWT_ACTIVE_SIGNING_KEYS',
               {'test': '0h7R8dL0rU-b3p3onft_BPfuRW1Ld7YjsFnOWJuFXUE'})
 def test_get_jwt(test_key_pair, test_jwk_payload, test_jwt):
     test_private_key = test_key_pair.export_to_pem(private_key=True,
@@ -51,7 +51,7 @@ def test_get_jwt(test_key_pair, test_jwk_payload, test_jwt):
 @patch.object(confidant.services.jwkmanager, 'datetime',
               Mock(wraps=datetime.datetime))
 @patch.object(confidant.services.jwkmanager, 'JWT_CACHING_ENABLED', True)
-@patch.object(confidant.services.jwkmanager, 'ACTIVE_SIGNING_KEYS',
+@patch.object(confidant.services.jwkmanager, 'JWT_ACTIVE_SIGNING_KEYS',
               {'test': '0h7R8dL0rU-b3p3onft_BPfuRW1Ld7YjsFnOWJuFXUE'})
 def test_get_jwt_caches_jwt(test_key_pair, test_jwk_payload, test_jwt):
     test_private_key = test_key_pair.export_to_pem(private_key=True,
@@ -91,7 +91,7 @@ def test_get_jwt_caches_jwt(test_key_pair, test_jwk_payload, test_jwt):
 @patch.object(confidant.services.jwkmanager, 'datetime',
               Mock(wraps=datetime.datetime))
 @patch.object(confidant.services.jwkmanager, 'JWT_CACHING_ENABLED', False)
-@patch.object(confidant.services.jwkmanager, 'ACTIVE_SIGNING_KEYS',
+@patch.object(confidant.services.jwkmanager, 'JWT_ACTIVE_SIGNING_KEYS',
               {'test': '0h7R8dL0rU-b3p3onft_BPfuRW1Ld7YjsFnOWJuFXUE'})
 def test_get_jwt_does_not_cache_jwt(test_key_pair, test_jwk_payload, test_jwt):
     test_private_key = test_key_pair.export_to_pem(private_key=True,
@@ -156,12 +156,12 @@ def test_get_jwks_not_found(test_key_pair, test_jwk_payload,
 
 @patch.object(confidant.services.jwkmanager, 'datetime',
               Mock(wraps=datetime.datetime))
-@patch.object(confidant.services.jwkmanager, 'ACTIVE_SIGNING_KEYS',
+@patch.object(confidant.services.jwkmanager, 'JWT_ACTIVE_SIGNING_KEYS',
               {'test': '0h7R8dL0rU-b3p3onft_BPfuRW1Ld7YjsFnOWJuFXUE'})
 def test_get_jwt_with_ca(test_jwk_payload, test_jwt,
                          test_certificate_authorities):
     with patch.object(confidant.services.jwkmanager,
-                      'CERTIFICATE_AUTHORITIES',
+                      'JWT_CERTIFICATE_AUTHORITIES',
                       test_certificate_authorities):
         confidant.services.jwkmanager.datetime.now.return_value = \
             datetime.datetime(


### PR DESCRIPTION
- Refactor settings that relate to our JWT PKI with `JWT_`, which makes it easier to know which configurations affect the PKI.
- Add `JWT_IS_CA_ENCRYPTED` setting that allows us to create an unencrypted base64 encoded `JWT_CERTIFICATE_AUTHORITIES` which is useful for local development