### PR TITLE
Fix Build Docs Action

### DIFF
--- a/docs/build.sh
+++ b/docs/build.sh
@@ -56,7 +56,7 @@ rm -rf "${GENERATED_RST_DIR}"
 mkdir -p "${GENERATED_RST_DIR}"
 
 source_venv "$BUILD_DIR"
-pip install -r "${SCRIPT_DIR}"/requirements.txt
+pip install -r "${SCRIPT_DIR}"/requirements3.txt
 
 rsync -av "${SCRIPT_DIR}"/root/ "${SCRIPT_DIR}"/conf.py "${GENERATED_RST_DIR}"
 


### PR DESCRIPTION
Edit the` build.sh` file for the `build docs` action by editing the required requirements file from `requirements.txt` to `requirements3.txt`.

Example of a failing action:

https://github.com/lyft/confidant/actions/runs/5871680344/job/15921642261