### PR TITLE
Pin mistune dependency in docs/requirements3.txt

### DIFF
--- a/docs/requirements3.txt
+++ b/docs/requirements3.txt
@@ -9,6 +9,7 @@ imagesize==0.7.1
 smmap==0.9.0
 snowballstemmer==1.2.1
 sphinx==2.2.0
+mistune<2.0.0
 sphinxcontrib-httpdomain==1.7.0
 sphinx_rtd_theme==0.4.3
 m2r==0.2.1


### PR DESCRIPTION
Pin the mistune dependency in the `docs/requirements3.txt` file to fix the doc build action.

Pinning to the 2.0.0 version per the following github [issue](https://github.com/Azure/azure-sdk-for-python/issues/22019#issuecomment-987195928)