### PR TITLE
Remove unused dependencies: greenlet, cffi

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -44,13 +44,6 @@ pynamodb>=3.2.1,<4
 # Use: For encryption
 cryptography>2.3.0
 
-# C Foreign Function Interface for Python.
-# License: MIT
-# Upstream url: https://bitbucket.org/cffi/cffi
-# Use: Required by cryptography package to be installed. This should be removed
-# once crytography updates their depenencies to require cffi>=1.10.0.
-cffi>1.10.0
-
 # License: BSD
 # Upstream url: https://github.com/fengsp/flask-session
 # Use: For shared sessions

--- a/requirements.in
+++ b/requirements.in
@@ -130,10 +130,6 @@ gunicorn
 # Use: For concurrency
 gevent
 
-# License: MIT
-# Upstream url: https://github.com/python-greenlet/greenlet
-# Use: For concurrency
-greenlet
 
 # License: MIT
 # Upstream url: https://github.com/jsocol/pystatsd

--- a/requirements3.txt
+++ b/requirements3.txt
@@ -30,7 +30,6 @@ certifi==2023.5.7
     # via requests
 cffi==1.15.1
     # via
-    #   -r requirements.in
     #   cryptography
 charset-normalizer==3.1.0
     # via requests

--- a/requirements3.txt
+++ b/requirements3.txt
@@ -70,9 +70,7 @@ gevent==22.10.2
     #   -r requirements.in
     #   pytest-gevent
 greenlet==2.0.2
-    # via
-    #   -r requirements.in
-    #   gevent
+    # via gevent
 guard==1.0.1
     # via -r requirements.in
 gunicorn==20.1.0


### PR DESCRIPTION
## Summary

This pull request addresses the removal of the unused dependencies `greenlet` and `cffi` from the project. It's part of an ongoing research endeavor focusing on the identification and elimination of code bloat within software projects. 

## Rationale

The `greenlet` dependency was added in 180a65e but remains unused, serving only as a transitive dependency. Similarly, the `cffi` dependency, added in 22088151, is no longer required due to updates in the `cryptography` [dependencies](https://github.com/pyca/cryptography/blob/58f110d9ebbf9a50a230846824417a1f57d19dda/pyproject.toml#L8).

Removing these unused dependencies contributes to a leaner codebase, reduces security risks, and simplifies dependency management.

## Changes

- Removed `greenlet` and `cffi` dependencies from `requirements.in`.
- Updated `requirements3.txt` to reflect the removed dependencies.

## Impact

- Decreased package size
- Enhanced project maintainability

I also signed the Contributor License Agreement (CLA) according to the contributing [guidelines](https://lyft.github.io/confidant/contributing.html#contributing)