### PR TITLE
Improve IAM Role cache

### DIFF
--- a/confidant/services/iamrolemanager.py
+++ b/confidant/services/iamrolemanager.py
@@ -26,8 +26,8 @@ def refresh_cache():
         # +/- 20ish seconds for respawn, to ensure all processes do not
         # refresh at the same time
         random_refresh_rate = random.randrange(
-            refresh_rate - 20,
-            refresh_rate + 20
+            refresh_rate - settings.BACKGROUND_CACHE_IAM_ROLE_JITTER,
+            refresh_rate + settings.BACKGROUND_CACHE_IAM_ROLE_JITTER
         )
         return gevent.spawn_later(
             random_refresh_rate,

--- a/confidant/services/iamrolemanager.py
+++ b/confidant/services/iamrolemanager.py
@@ -37,8 +37,9 @@ def refresh_cache():
 
 def get_iam_roles(purge=False):
     if settings.BACKGROUND_CACHE_IAM_ROLES:
+        global ROLES
         # If cache is empty, it hasn't been populated by the bg process yet
-        # Populate, then return
+        # Populate cache, then return
         if not ROLES:
             ROLES = _get_iam_roles()
         return ROLES

--- a/confidant/services/iamrolemanager.py
+++ b/confidant/services/iamrolemanager.py
@@ -37,11 +37,11 @@ def refresh_cache():
 
 def get_iam_roles(purge=False):
     if settings.BACKGROUND_CACHE_IAM_ROLES:
-        # If the cache is empty, assume it's not populated yet, and skip cache
+        # If cache is empty, it hasn't been populated by the bg process yet
+        # Populate, then return
         if not ROLES:
-            return _get_iam_roles()
-        else:
-            return ROLES
+            ROLES = _get_iam_roles()
+        return ROLES
     else:
         return _get_iam_roles()
 

--- a/confidant/services/iamrolemanager.py
+++ b/confidant/services/iamrolemanager.py
@@ -23,7 +23,7 @@ def refresh_cache():
             exc_info=True
         )
     finally:
-        # +/- 20ish seconds for respawn, to ensure all processes do not
+        # +/- seconds for respawn, to ensure all processes do not
         # refresh at the same time
         random_refresh_rate = random.randrange(
             refresh_rate - settings.BACKGROUND_CACHE_IAM_ROLE_JITTER,

--- a/confidant/settings.py
+++ b/confidant/settings.py
@@ -492,8 +492,9 @@ BACKGROUND_CACHE_IAM_ROLE_REFRESH_RATE = int_env(
     600
 )
 
-# Seconds to add as jitter to ensure all processes do not refresh at the same time
-# which can cause AWS ratelimits to be hit.  Default to 20 seconds.
+# Seconds to add as jitter to ensure all processes do not refresh at
+# the same time which can cause AWS ratelimits to be hit.
+# Default to 20 seconds
 BACKGROUND_CACHE_IAM_ROLE_JITTER = int_env(
     'BACKGROUND_CACHE_IAM_ROLE_JITTER',
     20

--- a/confidant/settings.py
+++ b/confidant/settings.py
@@ -491,6 +491,13 @@ BACKGROUND_CACHE_IAM_ROLE_REFRESH_RATE = int_env(
     600
 )
 
+# Seconds to add as jitter to ensure all processes do not refresh at the same time
+# which can cause AWS ratelimits to be hit.  Default to 30 seconds.
+BACKGROUND_CACHE_IAM_ROLE_JITTER = int_env(
+    'BACKGROUND_CACHE_IAM_ROLE_JITTER',
+    30
+)
+
 # ACM Private CA configuration
 
 # ACM_PRIVATE_CAS is a comma separated list of friendly ca names. Confidant

--- a/confidant/settings.py
+++ b/confidant/settings.py
@@ -484,7 +484,8 @@ AWS_DEFAULT_REGION = str_env('AWS_DEFAULT_REGION', 'us-east-1')
 # gevent thread.
 BACKGROUND_CACHE_IAM_ROLES = bool_env('BACKGROUND_CACHE_IAM_ROLES', True)
 # Number of seconds between calls to refresh the IAM role cache. Calls will be
-# randomized +/- by 20s, to randomize calls across processes. Minimum value for
+# randomized +/- by BACKGROUND_CACHE_IAM_ROLE_JITTER seconds,
+# to randomize calls across processes. Minimum value for
 # this setting is 60.
 BACKGROUND_CACHE_IAM_ROLE_REFRESH_RATE = int_env(
     'BACKGROUND_CACHE_IAM_ROLE_REFRESH_RATE',
@@ -492,10 +493,10 @@ BACKGROUND_CACHE_IAM_ROLE_REFRESH_RATE = int_env(
 )
 
 # Seconds to add as jitter to ensure all processes do not refresh at the same time
-# which can cause AWS ratelimits to be hit.  Default to 30 seconds.
+# which can cause AWS ratelimits to be hit.  Default to 20 seconds.
 BACKGROUND_CACHE_IAM_ROLE_JITTER = int_env(
     'BACKGROUND_CACHE_IAM_ROLE_JITTER',
-    30
+    20
 )
 
 # ACM Private CA configuration


### PR DESCRIPTION
- Allow jitter to be configurable
- Don't wait on background process to populate cache.  Instead, if on first fetch it's empty, populate.