### PR TITLE
Unpin kmsauth from v0.6.2 which was pulled due to problems

### DIFF
--- a/requirements3.txt
+++ b/requirements3.txt
@@ -93,7 +93,7 @@ jmespath==0.10.0
     #   botocore
 jwcrypto==1.5.0
     # via -r requirements.in
-kmsauth==0.6.2
+kmsauth
     # via -r requirements.in
 lru-dict==1.2.0
     # via -r requirements.in


### PR DESCRIPTION
kmsauth v0.6.2 does not exist in artifactory. Reverting confidant to previous reference behavior of pulling latest, rather than pinning to specific version.