### PR TITLE
add timer to key GET paths

### DIFF
--- a/confidant/routes/services.py
+++ b/confidant/routes/services.py
@@ -20,7 +20,7 @@ from confidant.services import (
     servicemanager,
     webhook,
 )
-from confidant.utils import maintenance, misc
+from confidant.utils import maintenance, misc, stats
 from confidant.utils.dynamodb import decode_last_evaluated_key
 
 logger = logging.getLogger(__name__)
@@ -122,48 +122,49 @@ def get_service_list():
     :statuscode 200: Success
     :statuscode 403: Client does not have permissions to list services.
     """
-    if not acl_module_check(resource_type='service',
-                            action='list'):
-        msg = "{} does not have access to list services".format(
-            authnz.get_logged_in_user()
-        )
-        error_msg = {'error': msg}
-        return jsonify(error_msg), 403
+    with stats.timer('list_services'):
+        if not acl_module_check(resource_type='service',
+                                action='list'):
+            msg = "{} does not have access to list services".format(
+                authnz.get_logged_in_user()
+            )
+            error_msg = {'error': msg}
+            return jsonify(error_msg), 403
 
-    limit = request.args.get(
-        'limit',
-        default=None,
-        type=int,
-    )
-    page = request.args.get(
-        'page',
-        default=None,
-        type=str
-    )
+        limit = request.args.get(
+            'limit',
+            default=None,
+            type=int,
+        )
+        page = request.args.get(
+            'page',
+            default=None,
+            type=str
+        )
 
-    if page:
-        try:
-            page = decode_last_evaluated_key(page)
-        except Exception:
-            logger.exception('Failed to parse provided page')
-            return jsonify({'error': 'Failed to parse page'}), 400
+        if page:
+            try:
+                page = decode_last_evaluated_key(page)
+            except Exception:
+                logger.exception('Failed to parse provided page')
+                return jsonify({'error': 'Failed to parse page'}), 400
 
-    if limit:
-        results = Service.data_type_date_index.query(
-            'service',
-            scan_index_forward=False,
-            limit=limit,
-            last_evaluated_key=page,
-        )
-        services_response = ServicesResponse.from_services(
-            [result for result in results],
-            next_page=results.last_evaluated_key
-        )
-    else:
-        services_response = ServicesResponse.from_services(
-            Service.data_type_date_index.query('service'),
-        )
-    return services_response_schema.dumps(services_response)
+        if limit:
+            results = Service.data_type_date_index.query(
+                'service',
+                scan_index_forward=False,
+                limit=limit,
+                last_evaluated_key=page,
+            )
+            services_response = ServicesResponse.from_services(
+                [result for result in results],
+                next_page=results.last_evaluated_key
+            )
+        else:
+            services_response = ServicesResponse.from_services(
+                Service.data_type_date_index.query('service'),
+            )
+        return services_response_schema.dumps(services_response)
 
 
 @blueprint.route('/v1/services/<id>', methods=['GET'])
@@ -233,92 +234,93 @@ def get_service(id):
     :statuscode 403: Client does not have permissions to get the service ID
                      provided.
     '''
-    permissions = {
-        'metadata': False,
-        'get': False,
-        'update': False,
-    }
-    metadata_only = misc.get_boolean(request.args.get('metadata_only'))
-    logged_in_user = authnz.get_logged_in_user()
-    action = 'metadata' if metadata_only else 'get'
-    if action == 'metadata':
-        permissions['metadata'] = acl_module_check(
-            resource_type='service',
-            action='metadata',
-            resource_id=id,
-        )
-    elif action == 'get':
-        permissions['get'] = acl_module_check(
-            resource_type='service',
-            action='get',
-            resource_id=id,
-        )
-    if not permissions[action]:
-        msg = "{} does not have access to get service {}".format(
-            authnz.get_logged_in_user(),
-            id
-        )
-        error_msg = {'error': msg, 'reference': id}
-        logger.warning(msg)
-        return jsonify(error_msg), 403
-
-    logger.info(
-        'get_service called on id={} by user={} metadata_only={}'.format(
-            id,
-            logged_in_user,
-            metadata_only,
-        )
-    )
-    try:
-        service = Service.get(id)
-        if not authnz.service_in_account(service.account):
-            logger.warning(
-                'Authz failed for service {0} (wrong account).'.format(id)
+    with stats.timer('get_service_by_id'):
+        permissions = {
+            'metadata': False,
+            'get': False,
+            'update': False,
+        }
+        metadata_only = misc.get_boolean(request.args.get('metadata_only'))
+        logged_in_user = authnz.get_logged_in_user()
+        action = 'metadata' if metadata_only else 'get'
+        if action == 'metadata':
+            permissions['metadata'] = acl_module_check(
+                resource_type='service',
+                action='metadata',
+                resource_id=id,
             )
-            msg = 'Authenticated user is not authorized.'
-            return jsonify({'error': msg}), 401
-    except DoesNotExist:
-        logger.warning('Item with id {0} does not exist.'.format(id))
-        return jsonify({}), 404
-    except Exception as e:
-        logger.warning('Exception occurred: {0}'.format(e))
-        raise e
-    if (service.data_type != 'service' and
-            service.data_type != 'archive-service'):
-        logger.warning('Item with id {0} is not a service.'.format(id))
-        return jsonify({}), 404
-    logger.debug('Authz succeeded for service {0}.'.format(id))
-    try:
-        credentials = credentialmanager.get_credentials(service.credentials)
-    except KeyError:
-        logger.exception('KeyError occurred in getting credentials')
-        return jsonify({'error': 'Decryption error.'}), 500
-    blind_credentials = credentialmanager.get_blind_credentials(
-        service.blind_credentials,
-    )
-    # TODO: this check can be expensive, so we're gating only to user auth.
-    # We should probably add an argument that opts in for permission hints,
-    # rather than always checking them.
-    if authnz.user_is_user_type('user'):
-        combined_cred_ids = (
-            list(service.credentials) + list(service.blind_credentials)
+        elif action == 'get':
+            permissions['get'] = acl_module_check(
+                resource_type='service',
+                action='get',
+                resource_id=id,
+            )
+        if not permissions[action]:
+            msg = "{} does not have access to get service {}".format(
+                authnz.get_logged_in_user(),
+                id
+            )
+            error_msg = {'error': msg, 'reference': id}
+            logger.warning(msg)
+            return jsonify(error_msg), 403
+
+        logger.info(
+            'get_service called on id={} by user={} metadata_only={}'.format(
+                id,
+                logged_in_user,
+                metadata_only,
+            )
         )
-        permissions['update'] = acl_module_check(
-            resource_type='service',
-            action='update',
-            resource_id=id,
-            kwargs={
-                'credential_ids': combined_cred_ids,
-            },
+        try:
+            service = Service.get(id)
+            if not authnz.service_in_account(service.account):
+                logger.warning(
+                    'Authz failed for service {0} (wrong account).'.format(id)
+                )
+                msg = 'Authenticated user is not authorized.'
+                return jsonify({'error': msg}), 401
+        except DoesNotExist:
+            logger.warning('Item with id {0} does not exist.'.format(id))
+            return jsonify({}), 404
+        except Exception as e:
+            logger.warning('Exception occurred: {0}'.format(e))
+            raise e
+        if (service.data_type != 'service' and
+                service.data_type != 'archive-service'):
+            logger.warning('Item with id {0} is not a service.'.format(id))
+            return jsonify({}), 404
+        logger.debug('Authz succeeded for service {0}.'.format(id))
+        try:
+            credentials = credentialmanager.get_credentials(service.credentials)
+        except KeyError:
+            logger.exception('KeyError occurred in getting credentials')
+            return jsonify({'error': 'Decryption error.'}), 500
+        blind_credentials = credentialmanager.get_blind_credentials(
+            service.blind_credentials,
         )
-    service_response = ServiceResponse.from_service_expanded(
-        service,
-        credentials=credentials,
-        blind_credentials=blind_credentials,
-        metadata_only=metadata_only,
-    )
-    service_response.permissions = permissions
-    return service_expanded_response_schema.dumps(service_response)
+        # TODO: this check can be expensive, so we're gating only to user auth.
+        # We should probably add an argument that opts in for permission hints,
+        # rather than always checking them.
+        if authnz.user_is_user_type('user'):
+            combined_cred_ids = (
+                list(service.credentials) + list(service.blind_credentials)
+            )
+            permissions['update'] = acl_module_check(
+                resource_type='service',
+                action='update',
+                resource_id=id,
+                kwargs={
+                    'credential_ids': combined_cred_ids,
+                },
+            )
+        service_response = ServiceResponse.from_service_expanded(
+            service,
+            credentials=credentials,
+            blind_credentials=blind_credentials,
+            metadata_only=metadata_only,
+        )
+        service_response.permissions = permissions
+        return service_expanded_response_schema.dumps(service_response)
 
 
 @blueprint.route('/v1/archive/services/<id>', methods=['GET'])


### PR DESCRIPTION
Was wondering what caused frontend to be so slow? did an analysis on UI and ranked captured network calls by timer. The slow and popular APIs are get and list services/credentials. Emitting stats to understand how slow it is and follow up on action items